### PR TITLE
fix: remove AUDIO_HOOK_README.md from sync process

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ To restore these configurations on a new computer:
    ```bash
    cp -r .claude ~/.claude
    cp settings.json ~/.claude/settings.json
-   cp docs/AUDIO_HOOK_README.md ~/.claude/AUDIO_HOOK_README.md
    ```
 
-**Alternative**: Once installed, you can use the `/sync` command from within this repository to update your configuration files automatically. The sync command will back up existing files and copy all configuration files including the audio notification system.
+**Alternative**: Once installed, you can use the `/sync` command from within this repository to update your configuration files automatically. The sync command will:
+- Back up existing files before overwriting
+- Copy CLAUDE.md, command files, agent configurations, and settings.json
+- Exclude repository-specific files (sync.md command and docs/ folder contents)
 
 ## Using Claude Commands
 
@@ -94,8 +96,11 @@ Once installed, you can use the following commands in Claude:
 - **`/sync`** - Sync configurations to user settings (repo-specific command)
   - Only available within the claude-config repository
   - Copies CLAUDE.md to ~/CLAUDE.md
-  - Copies command files to ~/.claude/commands/
+  - Copies command files to ~/.claude/commands/ (excludes sync.md)
+  - Copies agent configurations to ~/.claude/agents/
+  - Copies settings.json with audio hooks
   - Creates backups before overwriting
+  - Excludes repository documentation (docs/ folder)
 
 ## Repository Structure
 
@@ -109,13 +114,24 @@ claude-config/
 │   │   ├── push.md            # /push command
 │   │   ├── test.md            # /test command
 │   │   ├── context.md         # /context command
+│   │   ├── review.md          # /review command
+│   │   ├── security.md        # /security command
+│   │   ├── perf.md            # /perf command
+│   │   ├── docs.md            # /docs command
+│   │   ├── debug.md           # /debug command
+│   │   ├── orchestrate.md     # /orchestrate command
 │   │   └── sync.md            # /sync command (repo-specific)
+│   ├── agents/                 # Specialized agent configurations
+│   │   └── ...                # 19 agent configuration files
 │   └── settings.local.json    # Local settings
 ├── .github/                     # GitHub specific files
 │   ├── workflows/              # GitHub Actions workflows
 │   │   ├── ci.yml             # Main CI workflow
 │   │   └── pr-checks.yml      # Pull request checks
 │   └── BRANCH_PROTECTION.md   # Branch protection setup guide
+├── docs/                        # Repository documentation
+│   ├── AUDIO_HOOK_README.md    # Audio notification setup guide
+│   └── ...                     # Other documentation files
 ├── tests/                       # Test suite for configurations
 │   ├── commands/               # Tests for each command
 │   ├── config/                 # Configuration validation tests


### PR DESCRIPTION
## Summary
- Remove AUDIO_HOOK_README.md from the sync process as it's repository documentation
- Update README documentation to reflect current repository structure

## Changes Made
- Removed `cp docs/AUDIO_HOOK_README.md ~/.claude/AUDIO_HOOK_README.md` from installation instructions
- Updated repository structure diagram to include:
  - `docs/` folder with AUDIO_HOOK_README.md
  - All new command files (review, security, perf, docs, debug, orchestrate)
  - `agents/` folder with 19 agent configurations

## Test Plan
- [x] Verify sync command no longer references AUDIO_HOOK_README.md
- [x] Confirm README accurately reflects current repository structure
- [x] Check that AUDIO_HOOK_README.md remains in docs/ folder for reference

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to clarify the behavior of the `/sync` command.
  * Expanded repository structure section with new command documentation and a dedicated agents directory.
  * Added documentation for multiple new commands and specialized agent configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->