### PR TITLE
fix: simplify API documentation in resolve-cr command

### DIFF
--- a/.claude/commands/resolve-cr.md
+++ b/.claude/commands/resolve-cr.md
@@ -363,10 +363,8 @@ Planned features (not yet implemented):
    - `comment.user.login === "coderabbitai"`
    - `comment.user.type === "Bot"`
 2. **App/Bot ID Verification**:
-   - **Primary**: Check for CodeRabbit app_id in comment metadata using GraphQL API when available
-   - **REST API Limitation**: GitHub REST API has limited app_id visibility in comment metadata
-   - **Fallback**: Verify `user.login === "coderabbitai"` and `user.type === "Bot"` for REST API calls
-   - Verify GitHub App association with CodeRabbit through available metadata
+   - Check for CodeRabbit app_id in comment metadata
+   - Verify GitHub App association with CodeRabbit
 3. **Comment Source Verification**:
    - Ensure comment originates from CodeRabbit GitHub App
    - Validate comment structure matches CodeRabbit patterns


### PR DESCRIPTION
## Summary
- Simplifies API documentation in the `/resolve-cr` command
- Removes implementation-specific details about GraphQL vs REST API
- Keeps documentation focused on high-level requirements

## Changes
- Reverted the App/Bot ID Verification section to simpler, cleaner documentation
- Removed technical implementation details that could become outdated
- Maintains the core verification requirements without prescribing specific API approaches

## Why
The previous version included too much implementation detail about GitHub's API limitations, which:
1. Made the documentation harder to maintain
2. Could become outdated as GitHub's API evolves
3. Added complexity without improving clarity

This change keeps the documentation focused on what needs to be done, not how the GitHub API works internally.

🤖 Generated with [Claude Code](https://claude.ai/code)