### PR TITLE
Fix: Correct statusline color documentation

### DIFF
--- a/system-configs/.claude/statusline.sh
+++ b/system-configs/.claude/statusline.sh
@@ -18,7 +18,6 @@ last_prompt=$(echo "$input" | jq -r '.last_prompt.summary // "Ready"')
 git_branch=$(git branch --show-current 2>/dev/null || echo "no-git")
 
 # Color codes
-# \033[95m = pink (mode)
 # \033[31m = red (model)
 # \033[38;5;208m = orange (git branch)
 # \033[96m = bright cyan (directory - matches LSCOLORS 'G' for directories)


### PR DESCRIPTION
## Summary
- Removed incorrect pink/mode color reference from statusline.sh comments
- Documentation now correctly reflects that model name uses red color

## Changes
- Cleaned up color code comments to match actual implementation
- Model name correctly documented as using red color (`\033[31m`)

## Test plan
- [x] Verified statusline displays model name in red
- [x] Tested with sample data to confirm color output
- [x] Comments now accurately document the color scheme

🤖 Generated with [Claude Code](https://claude.ai/code)