### PR TITLE
docs: fix agent count inconsistencies and sanitize user paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 This is a **Claude Code CLI Configuration Management Repository** - a clean, organized system for managing Claude
 configurations, specialized agents, and custom commands. After a major cleanup that removed 85+ bloat files, this
-repository now contains essential configurations for running 26 specialized agents and 20 commands with the Claude
+repository now contains essential configurations for running 28 specialized agents and 20 commands with the Claude
 Code CLI.
 
 ## Repository-Specific Instructions
@@ -18,7 +18,7 @@ Code CLI.
 ### Key Components
 
 - **System Configurations**: Core Claude settings in `system-configs/` directory
-- **Agent Ecosystem**: 26 specialized agents in `system-configs/.claude/agents/`
+- **Agent Ecosystem**: 28 specialized agents in `system-configs/.claude/agents/`
 - **Commands**: 20 essential commands in `system-configs/.claude/commands/`
 - **Documentation**: 26 essential documentation files in `docs/`
 - **Scripts**: 9 utility scripts for validation and maintenance
@@ -74,7 +74,7 @@ Code CLI.
 ### Configuration Management
 
 - `/sync` - **Primary Command**: Synchronizes system configurations from this repository to `~/.claude/`
-- `/agent-audit` - Validates all 26 agent configurations with parallel execution
+- `/agent-audit` - Validates all 28 agent configurations with parallel execution
 - `/context` - Analyzes repository structure and purpose
 
 ### Development & Testing
@@ -95,13 +95,13 @@ Code CLI.
 
 - **system-configs/**: Contains the source-of-truth configurations
   - `CLAUDE.md`: Main configuration file
-  - `.claude/agents/`: 26 agent definitions in Markdown format
+  - `.claude/agents/`: 28 agent definitions in Markdown format
   - `.claude/commands/`: 20 command definitions
   - `settings.json`: Audio notification hooks and preferences
 
 ### Agent Categories
 
-The 41 agents are organized across multiple functional domains covering all aspects of software development, from
+The 28 agents are organized across multiple functional domains covering all aspects of software development, from
 core programming to infrastructure, quality assurance, and documentation.
 
 ### Synchronization System

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## 🎯 Overview
 
 This repository delivers a **sophisticated Smart Agent Orchestration Framework** for Claude Code CLI, featuring
-**41 specialized agents** with **multi-instance parallelization** delivering **4-6x performance improvements**.
+**28 specialized agents** with **multi-instance parallelization** delivering **4-6x performance improvements**.
 The system includes **18 essential commands** with advanced instance pooling architecture that enables
 multiple agents of the same type to work simultaneously. Built from the ground up after a comprehensive cleanup
 that removed 85+ bloat files, this system provides intelligent task delegation, massive parallel execution,
@@ -26,7 +26,7 @@ continuous improvement capabilities, and automatic command verification for enha
 
 ## 🧠 Smart Agent Orchestration Framework
 
-This repository implements a **production-ready orchestration framework** that intelligently manages 41 specialized
+This repository implements a **production-ready orchestration framework** that intelligently manages 28 specialized
 agents with sophisticated task delegation and parallel execution capabilities.
 
 ### 🌟 Framework Core Principles
@@ -58,7 +58,7 @@ agents with sophisticated task delegation and parallel execution capabilities.
 
 ### Key Framework Benefits
 
-- **🎭 41 Specialized Agents**: Complete coverage across 8 functional domains
+- **🎭 28 Specialized Agents**: Complete coverage across 8 functional domains
 - **⚡ Parallel Execution Engine**: Maximize concurrent operations for faster delivery
 - **🧠 Intelligent Task Delegation**: Automatic specialist selection based on task requirements
 - **🔄 One-Command Synchronization**: Deploy entire framework with `/sync`
@@ -312,7 +312,7 @@ See [ShellCheck Validation Documentation](docs/SHELLCHECK_VALIDATION.md) for com
 ```bash
 /agent-audit
 # Deploys 8 parallel agent-auditor instances across all categories
-# Comprehensive validation of 41 agent configurations
+# Comprehensive validation of 28 agent configurations
 # Performance metrics and capability gap analysis
 # Continuous improvement recommendations with quality feedback loops
 # Production-ready health monitoring for the entire orchestration framework
@@ -362,9 +362,9 @@ Note: Previously named `/resolve-rabbit`.
 # Prevents accidental force pushes
 ```
 
-## 🎭 Agent Ecosystem: 41 Specialists
+## 🎭 Agent Ecosystem: 28 Specialists
 
-The Smart Agent Orchestration Framework includes **41 specialized agents** organized across 8 functional domains,
+The Smart Agent Orchestration Framework includes **28 specialized agents** organized across 8 functional domains,
 with sophisticated parallel execution and multi-instance capabilities:
 
 ### 📊 Agent Categories Overview
@@ -526,7 +526,7 @@ Performance Tracking: Real-time capability assessment and gap analysis
 
 - **Production-Ready Orchestration**: Sophisticated task delegation with performance feedback loops
 - **Parallel-First Architecture**: Concurrent agent deployment optimized for maximum efficiency
-- **41 Specialized Agents**: Complete coverage across 8 functional domains with continuous expansion
+- **28 Specialized Agents**: Complete coverage across 8 functional domains with continuous expansion
 - **Intelligent Task Routing**: Automatic specialist selection based on task complexity and requirements
 - **Performance Monitoring**: Real-time execution metrics with continuous improvement algorithms
 - **Multi-Instance Coordination**: Scalable agent deployment with intelligent load balancing
@@ -552,7 +552,7 @@ claude-config/
 ├── system-configs/             # Source configurations
 │   ├── CLAUDE.md              # Core configuration file
 │   ├── .claude/               # Claude Code configuration
-│   │   ├── agents/            # 41 agent definitions + 5 docs
+│   │   ├── agents/            # 28 agent definitions + 5 docs
 │   │   │   ├── README.md      # Agent ecosystem guide
 │   │   │   └── *.md           # Individual agent specs
 │   │   └── commands/          # 18 command definitions
@@ -588,7 +588,7 @@ cd claude-config
 # One-command framework deployment
 /sync
 
-# Experience intelligent orchestration: 41 agents and 18 commands available
+# Experience intelligent orchestration: 28 agents and 18 commands available
 # Multi-agent repository analysis with performance optimization
 /context
 

--- a/docs/CONSOLIDATED_AGENT_SYSTEM.md
+++ b/docs/CONSOLIDATED_AGENT_SYSTEM.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-The agent ecosystem has been optimized to a focused set of 41 specialized agents, each with
+The agent ecosystem has been optimized to a focused set of 28 specialized agents, each with
 clear domain expertise and defined boundaries. This configuration eliminates redundancy
 while maintaining comprehensive coverage across all technical domains.
 

--- a/docs/CONSOLIDATED_AGENT_SYSTEM.md
+++ b/docs/CONSOLIDATED_AGENT_SYSTEM.md
@@ -216,7 +216,7 @@ codebase_understanding:
 - **Selection Accuracy**: >95% correct agent selection
 - **No Overlap**: Clear boundaries between agent responsibilities
 - **Complete Coverage**: All technical domains addressed
-- **Optimal Size**: 41 agents provide comprehensive coverage without redundancy
+- **Optimal Size**: 28 agents provide comprehensive coverage without redundancy
 
 ### Performance Optimization
 

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -10,7 +10,7 @@
 
 ### 🏠 Project Overview
 
-- **[README.md](../README.md)** - Configuration management system with 41 agents
+- **[README.md](../README.md)** - Configuration management system with 28 agents
   and 18 commands
 
 - **[CLAUDE.md](../CLAUDE.md)** - Repository-specific configuration instructions

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -403,5 +403,5 @@ git checkout -b feature/my-enhancement
 
 ---
 
-**Installation Complete!** You now have access to 41 specialized agents and 18 essential commands through the
+**Installation Complete!** You now have access to 28 specialized agents and 18 essential commands through the
 Claude Code CLI orchestration framework.

--- a/docs/NGROK_SETUP.md
+++ b/docs/NGROK_SETUP.md
@@ -179,7 +179,7 @@ Or use a simple cron job:
 crontab -e
 
 # Add this line
-@reboot /Users/damilola/start-mcp-dashboard.sh
+@reboot ~/start-mcp-dashboard.sh
 ```yaml
 
 ## Summary

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -110,7 +110,7 @@ Used in `/deps` for scanning dependencies:
 calculation: min(max_instances, ceil(work_items / items_per_instance))
 
 Examples:
-  - 40 agents, 8 max instances → 8 instances (5 agents each)
+  - 28 agents, 8 max instances → 8 instances (3-4 agents each)
   - 15 files, 5 max instances → 3 instances (5 files each)
   - 3 tests, 5 max instances → 1 instance (below threshold)
 ```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -32,7 +32,7 @@ High-level command APIs that provide workflow automation and developer experienc
 
 ### 🤖 Agent Ecosystem APIs
 
-APIs for managing and orchestrating the 41 specialized agents in the Claude ecosystem.
+APIs for managing and orchestrating the 28 specialized agents in the Claude ecosystem.
 
 | API | Description | Specification |
 |-----|-------------|---------------|

--- a/docs/guides/agent-migration-guide-v2.md
+++ b/docs/guides/agent-migration-guide-v2.md
@@ -102,7 +102,7 @@ category: development
 ### 4.1 Locate Agent File
 
 ```bash
-cd /Users/damilola/Documents/Projects/claude-config/.claude/agents/
+cd ~/Documents/Projects/claude-config/.claude/agents/
 ls -la *.md | grep -v AGENT_
 ```yaml
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,12 @@
 ## Overview
 
 This documentation provides comprehensive information about the consolidated
-Claude configuration system with 41 specialized agents, optimized workflows,
+Claude configuration system with 28 specialized agents, optimized workflows,
 and enhanced development processes.
 
 **System Highlights:**
 
-- **41 specialized agents** with clear functional boundaries
+- **28 specialized agents** with clear functional boundaries
 - **95% agent selection accuracy** with standardized naming
 - **Clear boundaries** and standardized naming conventions
 - **Enhanced parallel execution** patterns and coordination

--- a/docs/specs/agent-ecosystem-spec.md
+++ b/docs/specs/agent-ecosystem-spec.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-The Claude Agent Ecosystem provides 42 specialized AI agents for software development tasks. This production
+The Claude Agent Ecosystem provides 28 specialized AI agents for software development tasks. This production
 architecture achieves 95% selection accuracy while maintaining 100% functional coverage, enabling efficient parallel
 execution and domain-specific expertise across all software development lifecycle phases.
 
 **Key Features:**
 
-- **42 specialized agents** covering all development domains
+- **28 specialized agents** covering all development domains
 - **95% selection accuracy** with clear agent boundaries
 - **8 distinct categories** with standardized color coding
 - **Optimized coordination patterns** for parallel execution

--- a/system-configs/.claude/agents/README.md
+++ b/system-configs/.claude/agents/README.md
@@ -120,7 +120,7 @@ Support, coordination, and strategic planning agents
 
 The agent ecosystem uses three model tiers optimized for task complexity:
 
-### Current Distribution (41 agents)
+### Current Distribution (28 agents)
 
 - **Opus (7 agents, 16.7%)**: Strategic and high-complexity tasks
   - principal-architect, performance-specialist, project-orchestrator

--- a/system-configs/.claude/agents/README.md
+++ b/system-configs/.claude/agents/README.md
@@ -24,7 +24,7 @@ Multiple independent tasks? → Deploy in parallel.
 
 ## Overview
 
-The Claude agent ecosystem consists of 41 specialized agents organized across 8 functional domains, providing
+The Claude agent ecosystem consists of 28 specialized agents organized across 8 functional domains, providing
 comprehensive coverage of the software development lifecycle.
 This system follows the **"Right tool for the job"** principle with a **parallel-first execution strategy** for maximum
 efficiency.

--- a/system-configs/.claude/commands/sync.md
+++ b/system-configs/.claude/commands/sync.md
@@ -136,7 +136,7 @@ User: /sync
 Claude: 🔄 Syncing Claude configurations...
 📁 Source: system-configs/.claude/ (50 files)
 📁 Destination: ~/.claude/
-✅ Agents synced (41 files)
+✅ Agents synced (28 files)
 ✅ Commands synced (15 files)
 ✅ Output styles synced (8 files)
 ✅ Settings and statusline synced
@@ -149,7 +149,7 @@ Claude: 🔄 Syncing Claude configurations...
 User: /sync --dry-run
 Claude: 📖 Preview mode - no changes will be made
 Would sync:
-- 41 agent files to ~/.claude/agents/
+- 28 agent files to ~/.claude/agents/
 - 18 command files to ~/.claude/commands/
 - 8 output style files to ~/.claude/output-styles/
 - settings.json to ~/.claude/settings.json


### PR DESCRIPTION
## Summary
- Fixed agent count inconsistencies across all documentation (standardized to 28 agents)
- Removed hardcoded user paths for better security and portability
- Ensured documentation accuracy matches actual repository structure

## Changes Made
- Updated README.md: Changed all references from 26/41 agents to 28 agents
- Updated CLAUDE.md: Fixed agent counts from 26/41 to 28
- Updated docs/DOCUMENTATION_INDEX.md: Corrected agent count to 28
- Updated docs/CONSOLIDATED_AGENT_SYSTEM.md: Fixed optimal size reference
- Updated docs/PERFORMANCE.md: Adjusted example calculations for 28 agents
- Updated system-configs/.claude/commands/sync.md: Fixed example outputs
- Updated system-configs/.claude/agents/README.md: Corrected distribution count
- Sanitized user paths in docs/NGROK_SETUP.md and docs/guides/agent-migration-guide-v2.md

## Test Results
✅ All tests passed (14/14 test suites)
✅ Markdown quality validation passed
✅ Agent YAML validation passed
✅ Pre-commit and pre-push hooks passed

## Context
During documentation audit, discovered that documentation referenced 26, 41, and 28 agents inconsistently, while the actual repository contains exactly 28 agent files. This PR standardizes all references to the correct count and improves security by removing hardcoded user paths.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated all references of agent count to 28 (from 41/26) across README, CLAUDE.md, and docs.
  - Adjusted “Optimal Size” and distribution sections to reflect 28 agents.
  - Revised performance scaling example to 28 agents across 8 instances.
  - Updated sync command examples to show 28 agent files.
  - Switched absolute paths to home-relative (~) in NGROK setup and migration guide.
  - Refreshed documentation index to note “28 agents” in project overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->