### PR TITLE
fix: isolate test logs from production with --test flag

### DIFF
--- a/system-configs/.claude/statusline.sh
+++ b/system-configs/.claude/statusline.sh
@@ -26,6 +26,17 @@
 # - Version change: updates file with NEW_VERSION:1 (show stars)
 # - Same version: reads existing flag from file
 # - Unknown/invalid version: defaults to 1.0.100:1
+#
+# TEST MODE:
+# - Pass --test flag to use .tmp/terminal_versions/ instead of ~/.claude/terminal_versions/
+# - This isolates test logs from production logs
+
+# Parse command-line arguments
+TEST_MODE=0
+if [[ "$1" == "--test" ]]; then
+    TEST_MODE=1
+    shift  # Remove --test from arguments
+fi
 
 # Read Claude session data from stdin
 input=$(cat)
@@ -75,8 +86,18 @@ terminal_id="$(printf '%s' "$raw_id" | tr '/\n' '_' | tr -cd 'A-Za-z0-9._-')"
 [[ -n "$terminal_id" ]] || terminal_id="fallback_$$"
 
 # Version tracking files
-version_dir="$HOME/.claude"
-terminal_versions_dir="$version_dir/terminal_versions"
+if [[ "$TEST_MODE" -eq 1 ]]; then
+    # Test mode: use test directory specified by environment variable or default
+    if [[ -n "${CLAUDE_TEST_DIR:-}" ]]; then
+        terminal_versions_dir="${CLAUDE_TEST_DIR}/terminal_versions"
+    else
+        terminal_versions_dir=".tmp/terminal_versions"
+    fi
+else
+    # Production mode: use ~/.claude/terminal_versions/
+    version_dir="$HOME/.claude"
+    terminal_versions_dir="$version_dir/terminal_versions"
+fi
 terminal_version_file="$terminal_versions_dir/${terminal_id}"
 
 # Handle unknown/invalid version - use default 1.0.100


### PR DESCRIPTION
## Summary

This PR introduces complete test isolation for statusline and exit_hook scripts, preventing test executions from polluting production logs at `~/.claude/terminal_versions/events.log`. Test data (including version 9.x.x entries) will now be isolated to `.tmp/terminal_versions/` when tests run.

## Problem Solved

Tests were writing to production event logs, causing:
- Version 9.x.x test data appearing in `~/.claude/terminal_versions/events.log`
- Test terminal sessions mixing with real production sessions
- Difficulty distinguishing test events from production events

## Solution

Added `--test` flag to both `statusline.sh` and `exit_hook.sh` that redirects all terminal version tracking to an isolated test directory.

## Changes

### Core Implementation
- **statusline.sh**: Added `--test` flag parsing and conditional directory selection
- **exit_hook.sh**: Matching `--test` flag implementation for consistency
- **Environment Variable**: Support for `CLAUDE_TEST_DIR` for flexible test path configuration

### Test Updates
- Updated `test_statusline.sh` to use `--test` flag consistently
- Modified `test_statusline_comprehensive.sh` with complete test isolation
- Converted `test_statusline_edge_cases.sh` to isolated test directories
- Fixed path resolution issues when tests change directories

### Key Features
- **Complete Isolation**: Test logs go to `.tmp/terminal_versions/`, production stays in `~/.claude/terminal_versions/`
- **Backward Compatible**: Scripts work normally without `--test` flag
- **Flexible Paths**: Support for both relative and absolute test directories via `CLAUDE_TEST_DIR`
- **Clean Production Logs**: No more test pollution with version 9.x.x entries

## Test Results
✅ All tests passing
- 12/12 statusline tests pass
- 20/20 config tests pass  
- All pre-commit checks passed
- All pre-push checks passed

## Related Issues
Fixes the event log pollution issue discovered during statusline debugging.

## Breaking Changes
None - this is fully backward compatible. The `--test` flag is optional and production behavior is unchanged.