### PR TITLE
enhancement: add markdown linting standards to documentation-writing agents

### DIFF
--- a/system-configs/.claude/agents/api-architect.md
+++ b/system-configs/.claude/agents/api-architect.md
@@ -36,6 +36,19 @@ This agent requires substantial thinking depth due to:
 - **OpenAPI specification depth**: Comprehensive contract definition with all edge cases
 - **Multi-protocol orchestration**: REST, GraphQL, gRPC, and WebSocket integration
 
+## Documentation Standards
+
+MUST validate all markdown output:
+
+- **MD001**: Heading levels increment by one
+- **MD013**: Lines under 150 chars (except tables/code)
+- **MD022**: Headings surrounded by blank lines
+- **MD040**: Code blocks specify language
+- **MD047**: Files end with single newline
+- **MD050**: Use `**asterisks**` for bold
+
+See tech-writer agent for complete standards.
+
 ## YAML/OpenAPI Linting Standards
 
 ### OpenAPI Specification Standards

--- a/system-configs/.claude/agents/business-analyst.md
+++ b/system-configs/.claude/agents/business-analyst.md
@@ -34,6 +34,19 @@ Bridges business objectives with technical implementation through comprehensive 
 - Pure technical implementation without business context
 - Tasks better suited for product-strategist or tech-writer
 
+## Documentation Standards
+
+MUST validate all markdown output:
+
+- **MD001**: Heading levels increment by one
+- **MD013**: Lines under 150 chars (except tables/code)
+- **MD022**: Headings surrounded by blank lines
+- **MD040**: Code blocks specify language
+- **MD047**: Files end with single newline
+- **MD050**: Use `**asterisks**` for bold
+
+See tech-writer agent for complete standards.
+
 ## Coordination
 
 Works in parallel with product-strategist for product vision and tech-writer for documentation.

--- a/system-configs/.claude/agents/cloud-architect.md
+++ b/system-configs/.claude/agents/cloud-architect.md
@@ -36,6 +36,19 @@ This agent requires substantial thinking depth due to:
 - **Security and compliance**: Implementing frameworks across multiple cloud providers
 - **IaC development**: Creating reusable, scalable infrastructure templates
 
+## Documentation Standards
+
+MUST validate all markdown output:
+
+- **MD001**: Heading levels increment by one
+- **MD013**: Lines under 150 chars (except tables/code)
+- **MD022**: Headings surrounded by blank lines
+- **MD040**: Code blocks specify language
+- **MD047**: Files end with single newline
+- **MD050**: Use `**asterisks**` for bold
+
+See tech-writer agent for complete standards.
+
 ## Infrastructure as Code Linting Standards
 
 ### Terraform Standards

--- a/system-configs/.claude/agents/principal-architect.md
+++ b/system-configs/.claude/agents/principal-architect.md
@@ -36,6 +36,19 @@ This agent requires maximum thinking depth due to:
 - **Technology selection reasoning**: Evaluating trade-offs between multiple architectural approaches
 - **Risk mitigation strategies**: Comprehensive technical debt and bottleneck analysis
 
+## Documentation Standards
+
+MUST validate all markdown output:
+
+- **MD001**: Heading levels increment by one
+- **MD013**: Lines under 150 chars (except tables/code)
+- **MD022**: Headings surrounded by blank lines
+- **MD040**: Code blocks specify language
+- **MD047**: Files end with single newline
+- **MD050**: Use `**asterisks**` for bold
+
+See tech-writer agent for complete standards.
+
 ## Technical Documentation Standards
 
 ### Architecture Document Structure

--- a/system-configs/.claude/agents/product-strategist.md
+++ b/system-configs/.claude/agents/product-strategist.md
@@ -34,6 +34,19 @@ Bridges business objectives with technical capabilities to drive product success
 - Pure technical implementation without product context
 - Tasks better suited for business-analyst or ux-researcher
 
+## Documentation Standards
+
+MUST validate all markdown output:
+
+- **MD001**: Heading levels increment by one
+- **MD013**: Lines under 150 chars (except tables/code)
+- **MD022**: Headings surrounded by blank lines
+- **MD040**: Code blocks specify language
+- **MD047**: Files end with single newline
+- **MD050**: Use `**asterisks**` for bold
+
+See tech-writer agent for complete standards.
+
 ## Coordination
 
 Works in parallel with business-analyst for requirements and ux-researcher for user insights.

--- a/system-configs/.claude/agents/project-orchestrator.md
+++ b/system-configs/.claude/agents/project-orchestrator.md
@@ -34,6 +34,19 @@ Analyzes complex projects to recommend optimal workflow patterns and resource al
 - Simple single-agent tasks without coordination needs
 - Tasks better suited for principal-architect or business-analyst
 
+## Documentation Standards
+
+MUST validate all markdown output:
+
+- **MD001**: Heading levels increment by one
+- **MD013**: Lines under 150 chars (except tables/code)
+- **MD022**: Headings surrounded by blank lines
+- **MD040**: Code blocks specify language
+- **MD047**: Files end with single newline
+- **MD050**: Use `**asterisks**` for bold
+
+See tech-writer agent for complete standards.
+
 ## Coordination
 
 Works in parallel with principal-architect for technical strategy and business-analyst for requirements.

--- a/system-configs/.claude/agents/test-engineer.md
+++ b/system-configs/.claude/agents/test-engineer.md
@@ -39,6 +39,19 @@ Creates robust testing frameworks ensuring code quality through automated testin
 - Pure development without testing focus
 - Tasks better suited for code-reviewer or performance-engineer
 
+## Documentation Standards
+
+MUST validate all markdown output:
+
+- **MD001**: Heading levels increment by one
+- **MD013**: Lines under 150 chars (except tables/code)
+- **MD022**: Headings surrounded by blank lines
+- **MD040**: Code blocks specify language
+- **MD047**: Files end with single newline
+- **MD050**: Use `**asterisks**` for bold
+
+See tech-writer agent for complete standards.
+
 ## Coordination
 
 Works in parallel with all development agents for test coverage and code-reviewer for quality validation.

--- a/system-configs/.claude/agents/ux-researcher.md
+++ b/system-configs/.claude/agents/ux-researcher.md
@@ -34,6 +34,19 @@ Uncovers user needs through systematic research to drive evidence-based design d
 - Implementation without research requirements
 - Tasks better suited for ui-designer or product-strategist
 
+## Documentation Standards
+
+MUST validate all markdown output:
+
+- **MD001**: Heading levels increment by one
+- **MD013**: Lines under 150 chars (except tables/code)
+- **MD022**: Headings surrounded by blank lines
+- **MD040**: Code blocks specify language
+- **MD047**: Files end with single newline
+- **MD050**: Use `**asterisks**` for bold
+
+See tech-writer agent for complete standards.
+
 ## Coordination
 
 Works in parallel with ui-designer for design improvements and product-strategist for feature prioritization.


### PR DESCRIPTION
## Summary
Added lightweight markdown linting standards to 8 key agents that generate documentation to ensure consistent, high-quality markdown output.

## Changes
- Added Documentation Standards section to api-architect (API docs)
- Added Documentation Standards section to principal-architect (architecture docs)
- Added Documentation Standards section to cloud-architect (IaC templates)
- Added Documentation Standards section to business-analyst (requirements)
- Added Documentation Standards section to product-strategist (PRDs)
- Added Documentation Standards section to ux-researcher (research reports)
- Added Documentation Standards section to project-orchestrator (project plans)
- Added Documentation Standards section to test-engineer (test reports)

## Context
These agents frequently write markdown documentation but lacked explicit linting guidance. By adding minimal linting standards (Option C from analysis), each agent now validates output for essential rules like heading hierarchy, line length, and code block languages. All agents reference tech-writer for complete standards.

## Testing
✅ All markdown files pass linting validation
✅ Configuration tests pass
✅ Agent YAML validation successful

## Implementation Details
- Used lightweight checklist approach (6 essential rules)
- Fixed MD032 violations during implementation
- Maintains consistency with tech-writer's comprehensive standards