### PR TITLE
fix: resolve rabbit interaction input waiting and exit hook flag logic

### DIFF
--- a/scripts/resolve-cr-optimized.sh
+++ b/scripts/resolve-cr-optimized.sh
@@ -2,6 +2,15 @@
 
 # Optimized /resolve-cr command implementation
 # Fetches and processes CodeRabbit review comments with parallel operations
+#
+# Usage:
+#   resolve-cr-optimized.sh [PR_NUMBER] [--auto]
+#
+# Arguments:
+#   PR_NUMBER  - Optional PR number. If not provided, detects from current branch
+#   --auto     - Skip interactive confirmation and proceed automatically
+#
+# Default behavior is interactive mode with user confirmation before proceeding
 
 set -e
 
@@ -13,7 +22,24 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Parse arguments
-PR_NUMBER="${1:-}"
+AUTO_MODE=false
+PR_NUMBER=""
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --auto)
+            AUTO_MODE=true
+            shift
+            ;;
+        *)
+            if [[ -z "$PR_NUMBER" ]]; then
+                PR_NUMBER="$1"
+            fi
+            shift
+            ;;
+    esac
+done
 
 # Get repository info
 REPO_INFO=$(gh repo view --json owner,name)
@@ -182,6 +208,19 @@ echo -e "\n📂 Affected Files:"
 echo "$PROMPTS" | jq -r 'group_by(.file) | .[] | "• \(.[0].file) (\(length) issue\(if length > 1 then "s" else "" end))"'
 
 echo "────────────────────────────────────────────────────────────"
+
+# Interactive confirmation (unless in auto mode)
+if [[ "$AUTO_MODE" != "true" ]]; then
+    echo ""
+    echo "Would you like to deploy parallel fix agents? (y/n): "
+    read -r response
+    if [[ "$response" != "y" && "$response" != "Y" ]]; then
+        echo "Wave deployment cancelled. No changes made."
+        exit 0
+    fi
+    echo ""
+fi
+
 echo "Proceeding with automated resolution..."
 echo "────────────────────────────────────────────────────────────"
 

--- a/tests/config/test_statusline.sh
+++ b/tests/config/test_statusline.sh
@@ -428,18 +428,18 @@ test_exit_hook() {
     # Run exit hook from /tmp directory with same version (simulating Claude session end from same dir)
     (cd /tmp && HOME="$TEST_HOME" echo '{"version":"8.0.0"}' | bash "$exit_hook_path" --test)
 
-    # Check file now has flag=0
+    # Check file now has flag=1 (preserved)
     content=$(cat "$terminal_file" 2>/dev/null)
-    if [[ "$content" != "8.0.0:0" ]]; then
-        echo "Exit hook should set flag to 0, got: $content"
+    if [[ "$content" != "8.0.0:1" ]]; then
+        echo "Exit hook should preserve flag=1, got: $content"
         return 1
     fi
 
-    # Run statusline again - should NOT show stars
+    # Run statusline again - should STILL show stars (flag preserved)
     HOME="$TEST_HOME" output=$(echo "$test_input" | bash "$statusline_path" --test 2>/dev/null)
 
-    if [[ "$output" == *"8.0.0 ✨"* ]]; then
-        echo "Should not show stars after exit hook: $output"
+    if [[ "$output" != *"8.0.0 ✨"* ]]; then
+        echo "Should still show stars after exit hook (flag preserved): $output"
         return 1
     fi
 


### PR DESCRIPTION
## Summary
Fix resolve rabbit command interaction flow to properly wait for user input and correct exit hook flag preservation logic.

## Changes
- Add missing interactive mode implementation to `resolve-cr-optimized.sh`
- Fix exit hook to preserve existing flags instead of resetting them
- Add argument parsing for `--auto` flag to support both interactive and automated modes
- Update flag management so only the 6-hour timer controls flag expiration

## Context
The resolve rabbit command was bypassing user input confirmation due to architectural inconsistency between command definition and optimized script implementation. Additionally, the exit hook was incorrectly resetting flags on every session end, preventing stars from persisting across quit/restart cycles.

## Testing
- Interactive mode now properly prompts: "Would you like to deploy parallel fix agents? (y/n):"
- Auto mode bypasses prompts when `--auto` flag is used
- Exit hook preserves existing flags, only updates on version upgrades
- Stars persist across sessions until 6-hour timer expires

## Related Issues
Resolves the rabbit interaction input waiting issue and statusline star persistence behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added non-interactive auto mode for the resolution script.
  - Auto-detects the pull request for the current branch when not provided.
  - Interactive confirmation prompts for deploying parallel fix agents (skipped in auto mode).

- Documentation
  - Expanded usage guidance and inline help for the resolution script.

- Chores
  - Improved logging with clearer event types and messages.
  - Preserves existing flags on same-version updates; upgrades flags when newer.
  - Explicit handling and logging when no version file is present.

- Tests
  - Updated exit-hook tests to expect flag preservation and continued status display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->