### PR TITLE
feat: update plan command to use $PLANS_DIR for output location

### DIFF
--- a/system-configs/.claude/commands/plan.md
+++ b/system-configs/.claude/commands/plan.md
@@ -73,7 +73,7 @@ Ready to proceed to Wave 5? (yes/no/modify)
 
 User: yes
 Claude: ## Wave 5: Final Implementation Strategy
-✅ Comprehensive plan approved! Creating implementation files in .tmp/authentication/:
+✅ Comprehensive plan approved! Creating implementation files in $PLANS_DIR/<repo-name>/authentication/:
 - prd.md
 - phase_1_pr_1_database.md (3 tasks)
 - phase_1_pr_2_services.md (4 tasks)
@@ -110,7 +110,7 @@ Phases: 1 phase, 1 PR, 5 tasks
 Ready to proceed to implementation? (yes/no/modify)
 
 User: yes
-Claude: ✅ Approved! Creating implementation files in .tmp/user-profile/:
+Claude: ✅ Approved! Creating implementation files in $PLANS_DIR/<repo-name>/user-profile/:
 - prd.md
 - phase_1_pr_1_user_profile.md (5 tasks)
 ```
@@ -403,6 +403,8 @@ Technology: React/Vue→frontend-architect, Node/Python→backend-engineer, K8s�
 
 #### Generated Files
 
+All files are created in `$PLANS_DIR/<repo-name>/<feature-name>/`:
+
 - `prd.md` - Product Requirements Document
 - `phase_X_pr_Y_<description>.md` - PR implementation files
 - `rollback.md` - Rollback procedures (if needed)
@@ -527,7 +529,7 @@ Deploy execution-evaluator to verify:
 - ✅ **PRD generated** - Complete Product Requirements Document created
 - ✅ **Tasks broken down** - Granular tasks with proper agent assignments
 - ✅ **Dependencies mapped** - Clear task sequencing and coordination
-- ✅ **Files created** - All phase files generated in .tmp/`feature-name`/
+- ✅ **Files created** - All phase files generated in $PLANS_DIR/`repo-name`/`feature-name`/
 - ✅ **Agent assignments** - Specialized agents properly matched via comprehensive wave analysis
 - ✅ **PRD compliance** - All requirements traceable through task breakdown
 - ✅ **Phase organization** - Clear dependencies and parallel execution plans


### PR DESCRIPTION
## Summary
Update the plan command to use a configurable `$PLANS_DIR` environment variable for storing generated planning files instead of the hardcoded `.tmp/` directory.

## Changes
- Replace all `.tmp/` references with `$PLANS_DIR/<repo-name>/<feature-name>/`
- Add explicit documentation about the new file structure location
- Update verification checklist to reflect new directory structure
- Maintain consistency across all examples and command output

## Context
This change provides better organization and environment-specific plan storage. The hierarchical structure with repository and feature-level organization allows users to define where planning artifacts are stored while maintaining clear separation between different projects and features.

## Testing
The changes have been reviewed and validated to ensure:
- All `.tmp/` references have been updated
- Documentation is clear and consistent
- Examples correctly show the new structure
- No functional changes to the command logic

## Impact
This is a non-breaking change as it uses an environment variable that can be configured per user environment. The implement command will work with files from any specified path.

🤖 Generated with [Claude Code](https://claude.ai/code)