### PR TITLE
chore: remove redundant agent routing table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,19 +370,6 @@ jobs:
           ! -name "README.md" ! -name "*TEMPLATE*" 2>/dev/null | wc -l | tr -d ' ')
         echo "Actual skills deployed: $actual_skills"
 
-        # Check if CLAUDE.md agent routing table has all agents listed
-        if [ -f "system-configs/CLAUDE.md" ]; then
-          # Extract agent names from routing table
-          routing_agents=$(grep -E '^\| .+ \| `[a-z-]+` \|' system-configs/CLAUDE.md 2>/dev/null | \
-            sed -n 's/.*`\([a-z-]*\)`.*/\1/p' | sort -u | wc -l | tr -d ' ')
-
-          if [ "$routing_agents" -lt "$actual_agents" ]; then
-            echo "❌ Agent routing table is incomplete"
-            echo "   Routing table has $routing_agents agents, but $actual_agents are deployed"
-            exit_code=1
-          fi
-        fi
-
         # Verify required agents exist
         required_agents=(
           "architect"

--- a/system-configs/CLAUDE.md
+++ b/system-configs/CLAUDE.md
@@ -12,16 +12,3 @@ correct. Never call work complete without verification.
 
 Temporary files go in `.tmp/`: `.tmp/plans/`, `.tmp/reports/`, `.tmp/analysis/`,
 `.tmp/drafts/`. Never in repo root or source directories.
-
-## Agent Routing
-
-| Keywords | Agent |
-|----------|-------|
-| fix, bug, crash, error, broken, slow, performance, memory | `debugger` |
-| security, vulnerability, auth, injection | `security-auditor` |
-| architecture, system design, infrastructure | `architect` |
-| frontend, ui, component, react, css | `frontend-engineer` |
-| test, spec, coverage | `test-engineer` |
-| review, check, audit, quality | `code-reviewer` |
-| deploy, ci/cd, pipeline, docker, kubernetes | `devops` |
-| implement feature, build feature | `feature-agent` |


### PR DESCRIPTION
## Summary
- Removes the Agent Routing table from `system-configs/CLAUDE.md`
- Agent routing is handled by Claude Code's built-in `subagent_type` parameter and agent description matching, making this table redundant
- Completes the CLAUDE.md minimization started in #183

## Test plan
- [x] All 19 config tests pass
- [x] Pre-commit and pre-push hooks pass
- [x] CLAUDE.md effectiveness score: 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD pipeline by removing agent routing validation step
  * Removed agent routing directives from system configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->