### PR TITLE
feat: add skipDangerousModePermissionPrompt to settings

### DIFF
--- a/system-configs/.claude/settings.json
+++ b/system-configs/.claude/settings.json
@@ -9,6 +9,7 @@
     "type": "command",
     "command": "${HOME}/.claude/statusline.sh"
   },
+  "skipDangerousModePermissionPrompt": true,
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary
- Adds `skipDangerousModePermissionPrompt: true` to `system-configs/.claude/settings.json`
- Suppresses the bypass permissions confirmation prompt when launching Claude Code in dangerous mode

## Test plan
- [ ] Run `/sync` to deploy updated settings to `~/.claude/settings.json`
- [ ] Launch Claude Code in bypass permissions mode and verify the warning prompt no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)