### PR TITLE
feat(changelog): SessionStart version-check hook + /changelog skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ The sync process deploys the complete framework configuration:
   ✅ Agents: 12 files → ~/.claude/agents/
   ✅ Commands: 20 files → ~/.claude/commands/
   ✅ Output styles: 8 files → ~/.claude/output-styles/
-  ✅ Settings: settings.json, statusline.sh
+  ✅ Settings: settings.json, statusline.sh, exit_hook.sh, session_start_version_check.sh
 
 📡 MCP Server Configuration:
   ✅ Updated Claude Desktop config with MCP servers:
@@ -521,8 +521,10 @@ claude-config/
 │   │   │   ├── verify.md
 │   │   │   └── ... (15 more commands)
 │   │   ├── output-styles/         # Formatting configurations
-│   │   ├── settings.json          # Audio notifications and preferences
-│   │   └── statusline.sh          # Terminal statusline integration
+│   │   ├── settings.json          # Hook configuration and audio preferences
+│   │   ├── statusline.sh          # Terminal statusline integration
+│   │   ├── exit_hook.sh           # SessionEnd cleanup hook
+│   │   └── session_start_version_check.sh  # SessionStart upgrade/CHANGELOG capture hook
 ├── docs/                          # 42 comprehensive documentation files
 │   ├── setup/                     # Installation and configuration guides
 │   ├── development/               # Development guidelines and requirements

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ The sync process deploys the complete framework configuration:
 
 🔄 Synchronizing files:
   ✅ Agents: 12 files → ~/.claude/agents/
-  ✅ Commands: 20 files → ~/.claude/commands/
+  ✅ Skills: 34 skills → ~/.claude/skills/
   ✅ Output styles: 8 files → ~/.claude/output-styles/
   ✅ Settings: settings.json, statusline.sh, exit_hook.sh, session_start_version_check.sh
 

--- a/docs/setup/AUDIO_HOOK_README.md
+++ b/docs/setup/AUDIO_HOOK_README.md
@@ -55,13 +55,22 @@ relevant CHANGELOG slice for the `/changelog` skill to replay on demand.
   CHANGELOG slice for versions in `(stored, current]`, consumed by
   `/changelog`)
 - **Log file**: `~/.claude/logs/session_start_version_check.log`
-- **Baseline**: First run with no state file seeds `BASELINE_VERSION=2.1.100`
-  so the very first real upgrade after deploy produces a slice.
+- **First run**: When the state file does not exist, the hook seeds it
+  with the currently-resolved `claude --version` and exits **without
+  producing a slice**. No `last_upgrade.md` is written on first run.
+  The first real upgrade *after* init is what triggers the first slice,
+  so new installs never see a fabricated "upgrade from arbitrary
+  baseline → now" on their first session.
 - **Failure policy**: Every error path exits 0 with no stdout. Session
   startup must never be blocked or delayed — the hook has a 5-second timeout
   in `settings.json` and silently no-ops on network/curl failures.
 - **Test mode**: Pass `--test` to isolate state under
-  `$CLAUDE_TEST_DIR` (defaults to `.tmp/session_start_check/`).
+  `$CLAUDE_TEST_DIR` (defaults to `.tmp/session_start_check/`). To
+  verify init on a clean slate: `rm -rf .tmp/session_start_check &&
+  ./session_start_version_check.sh --test && cat
+  .tmp/session_start_check/last_seen_claude_version` — you should see
+  the currently-installed CLI version and no slice file under
+  `.tmp/session_start_check/cache/`.
 
 The hook writes nothing to stdout, so it does not affect the model context.
 The user-facing "what's new" experience is served by the statusline's upgrade

--- a/docs/setup/AUDIO_HOOK_README.md
+++ b/docs/setup/AUDIO_HOOK_README.md
@@ -37,6 +37,36 @@ In addition to audio hooks, `PreToolUse` hooks enforce quality policies:
 - **--no-verify blocker**: Command-based hook that blocks `--no-verify` and `--no-gpg-sign` flags on Bash commands (exit code 2 = block)
 - **Destructive git detector**: Prompt-based hook (haiku model) that analyzes Bash commands for destructive git operations (`reset --hard`, `push --force`, `clean -f`, `branch -D`)
 
+### Session Version-Check Hook
+
+A command-based `SessionStart` hook runs `~/.claude/session_start_version_check.sh`
+on every real session startup (source == `startup`; resume/clear/compact are
+skipped). Its job is to detect Claude Code CLI upgrades and persist the
+relevant CHANGELOG slice for the `/changelog` skill to replay on demand.
+
+- **Script**: `system-configs/.claude/session_start_version_check.sh` (synced
+  to `~/.claude/session_start_version_check.sh` by `/sync`)
+- **State file**: `~/.claude/last_seen_claude_version` (plain text, one
+  semver line, `chmod 600`)
+- **Cache file**: `~/.claude/cache/claude-code-changelog.md` (full upstream
+  CHANGELOG, 24h TTL, refetched from
+  `https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`)
+- **Slice file**: `~/.claude/cache/last_upgrade.md` (YAML header + raw
+  CHANGELOG slice for versions in `(stored, current]`, consumed by
+  `/changelog`)
+- **Log file**: `~/.claude/logs/session_start_version_check.log`
+- **Baseline**: First run with no state file seeds `BASELINE_VERSION=2.1.100`
+  so the very first real upgrade after deploy produces a slice.
+- **Failure policy**: Every error path exits 0 with no stdout. Session
+  startup must never be blocked or delayed — the hook has a 5-second timeout
+  in `settings.json` and silently no-ops on network/curl failures.
+- **Test mode**: Pass `--test` to isolate state under
+  `$CLAUDE_TEST_DIR` (defaults to `.tmp/session_start_check/`).
+
+The hook writes nothing to stdout, so it does not affect the model context.
+The user-facing "what's new" experience is served by the statusline's upgrade
+indicator plus the `/changelog` skill, which reads `last_upgrade.md`.
+
 ### Settings Configuration
 
 Add to `$HOME/.claude/settings.json`:
@@ -73,6 +103,17 @@ Add to `$HOME/.claude/settings.json`:
           {
             "type": "command",
             "command": "afplay -v 1.0 '/System/Library/PrivateFrameworks/ToneLibrary.framework/Versions/A/Resources/AlertTones/Modern/Aurora.m4r' 2>/dev/null &"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/.claude/session_start_version_check.sh",
+            "timeout": 5
           }
         ]
       }

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -292,10 +292,17 @@ sync_files() {
         print_error "bash not available — required to validate hook scripts"
         return 1
     fi
+    # RUNTIME_HOOK_SCRIPTS is the declarative source of truth. Every
+    # entry MUST exist in the source tree — silently skipping missing
+    # entries lets /sync report success while settings.json still points
+    # at a hook that was never installed. Fail fast so that class of
+    # drift is impossible.
     for script in $RUNTIME_HOOK_SCRIPTS; do
         src="$SOURCE_DIR/$script"
         if [ ! -f "$src" ]; then
-            continue  # optional entry not present, skip silently
+            print_error "Tracked hook script missing from source tree: $script"
+            print_error "RUNTIME_HOOK_SCRIPTS lists '$script' but it is not present in $SOURCE_DIR"
+            return 1
         fi
         validation_errors=$(bash -n "$src" 2>&1) || {
             print_error "Invalid shell script: $script"
@@ -306,12 +313,12 @@ sync_files() {
         chmod +x "$TARGET_DIR/$script"
     done
 
-    # Build synced settings summary line from the same map.
+    # Build synced settings summary line from the same map. Every entry
+    # is guaranteed to exist at this point (the loop above would have
+    # returned on any missing script), so no `-f` guard is needed.
     synced_settings="settings.json"
     for script in $RUNTIME_HOOK_SCRIPTS; do
-        if [ -f "$SOURCE_DIR/$script" ]; then
-            synced_settings="$synced_settings, $script"
-        fi
+        synced_settings="$synced_settings, $script"
     done
     echo "  ✅ Settings: $synced_settings"
 
@@ -381,6 +388,8 @@ main() {
         for script in $RUNTIME_HOOK_SCRIPTS; do
             if [ -f "$SOURCE_DIR/$script" ]; then
                 echo "  - $script → ~/.claude/$script"
+            else
+                echo "  - $script ⚠️  MISSING from source tree (real sync would fail)"
             fi
         done
         echo ""

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -24,6 +24,11 @@ TARGET_DIR="$HOME/.claude"
 # hooks. To add a new hook script: add its filename here and wire it into
 # settings.json. Both sync_files() and the dry-run preview read from this
 # single source of truth.
+#
+# NOTE: space-delimited. Filenames MUST NOT contain spaces — the loops
+# below rely on unquoted word-splitting to iterate this list. If a hook
+# script ever needs a space in its name, switch this to a newline-delimited
+# heredoc and iterate with `while read`.
 RUNTIME_HOOK_SCRIPTS="statusline.sh exit_hook.sh session_start_version_check.sh"
 
 # Parse arguments
@@ -277,12 +282,22 @@ sync_files() {
 
     # Sync each tracked hook script: validate syntax, copy, make executable.
     # RUNTIME_HOOK_SCRIPTS is defined at the top of this file.
+    #
+    # All shipped hooks have a `#!/bin/bash` shebang and use bash-only
+    # constructs (`local`, `[[ ]]`, `=~`). We validate with `bash -n` so
+    # Linux (where /bin/sh is dash) doesn't false-positive on bashisms.
+    # macOS /bin/sh is bash-compat which is why `sh -n` previously slipped
+    # through during local dev.
+    if ! command -v bash >/dev/null 2>&1; then
+        print_error "bash not available — required to validate hook scripts"
+        return 1
+    fi
     for script in $RUNTIME_HOOK_SCRIPTS; do
         src="$SOURCE_DIR/$script"
         if [ ! -f "$src" ]; then
             continue  # optional entry not present, skip silently
         fi
-        validation_errors=$(sh -n "$src" 2>&1) || {
+        validation_errors=$(bash -n "$src" 2>&1) || {
             print_error "Invalid shell script: $script"
             printf "    %s\n" "$validation_errors"
             return 1

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -19,6 +19,13 @@ REPO_DIR="$(dirname "$SCRIPT_DIR")"
 SOURCE_DIR="$REPO_DIR/system-configs/.claude"
 TARGET_DIR="$HOME/.claude"
 
+# Declarative map of runtime hook scripts that sync deploys to ~/.claude/.
+# Each entry is a filename under $SOURCE_DIR, referenced from settings.json
+# hooks. To add a new hook script: add its filename here and wire it into
+# settings.json. Both sync_files() and the dry-run preview read from this
+# single source of truth.
+RUNTIME_HOOK_SCRIPTS="statusline.sh exit_hook.sh session_start_version_check.sh"
+
 # Parse arguments
 DRY_RUN=false
 CREATE_BACKUP=true
@@ -268,30 +275,29 @@ sync_files() {
         cp "$SOURCE_DIR/settings.json" "$TARGET_DIR/"
     fi
 
-    if [ -f "$SOURCE_DIR/statusline.sh" ]; then
-        validation_errors=$(sh -n "$SOURCE_DIR/statusline.sh" 2>&1) || {
-            print_error "Invalid shell script: statusline.sh"
+    # Sync each tracked hook script: validate syntax, copy, make executable.
+    # RUNTIME_HOOK_SCRIPTS is defined at the top of this file.
+    for script in $RUNTIME_HOOK_SCRIPTS; do
+        src="$SOURCE_DIR/$script"
+        if [ ! -f "$src" ]; then
+            continue  # optional entry not present, skip silently
+        fi
+        validation_errors=$(sh -n "$src" 2>&1) || {
+            print_error "Invalid shell script: $script"
             printf "    %s\n" "$validation_errors"
             return 1
         }
-        cp "$SOURCE_DIR/statusline.sh" "$TARGET_DIR/"
-        chmod +x "$TARGET_DIR/statusline.sh"
-    fi
+        cp "$src" "$TARGET_DIR/"
+        chmod +x "$TARGET_DIR/$script"
+    done
 
-    if [ -f "$SOURCE_DIR/exit_hook.sh" ]; then
-        validation_errors=$(sh -n "$SOURCE_DIR/exit_hook.sh" 2>&1) || {
-            print_error "Invalid shell script: exit_hook.sh"
-            printf "    %s\n" "$validation_errors"
-            return 1
-        }
-        cp "$SOURCE_DIR/exit_hook.sh" "$TARGET_DIR/"
-        chmod +x "$TARGET_DIR/exit_hook.sh"
-    fi
-
-    # Build synced settings list dynamically
+    # Build synced settings summary line from the same map.
     synced_settings="settings.json"
-    [ -f "$SOURCE_DIR/statusline.sh" ] && synced_settings="$synced_settings, statusline.sh"
-    [ -f "$SOURCE_DIR/exit_hook.sh" ] && synced_settings="$synced_settings, exit_hook.sh"
+    for script in $RUNTIME_HOOK_SCRIPTS; do
+        if [ -f "$SOURCE_DIR/$script" ]; then
+            synced_settings="$synced_settings, $script"
+        fi
+    done
     echo "  ✅ Settings: $synced_settings"
 
     # Sync main CLAUDE.md to home directory
@@ -357,8 +363,11 @@ main() {
         echo "  - $(find "$SOURCE_DIR/agents" -name "*.md" 2>/dev/null | wc -l | tr -d ' ') agent files → ~/.claude/agents/"
         echo "  - $(find "$SOURCE_DIR/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ') skills → ~/.claude/skills/"
         echo "  - settings.json → ~/.claude/settings.json"
-        [ -f "$SOURCE_DIR/statusline.sh" ] && echo "  - statusline.sh → ~/.claude/statusline.sh"
-        [ -f "$SOURCE_DIR/exit_hook.sh" ] && echo "  - exit_hook.sh → ~/.claude/exit_hook.sh"
+        for script in $RUNTIME_HOOK_SCRIPTS; do
+            if [ -f "$SOURCE_DIR/$script" ]; then
+                echo "  - $script → ~/.claude/$script"
+            fi
+        done
         echo ""
         echo "📊 Preview summary:"
         echo "  Total files: $(find "$SOURCE_DIR" -name "*.md" -o -name "*.json" -o -name "*.sh" 2>/dev/null | wc -l | tr -d ' ') configurations ready"

--- a/scripts/test-config-integrity.py
+++ b/scripts/test-config-integrity.py
@@ -26,11 +26,12 @@ SKILLS_DIR = PROJECT_ROOT / "system-configs" / ".claude" / "skills"
 # Expected counts
 # 8 agents: architect, code-reviewer, debugger, devops, feature-agent,
 #   frontend-engineer, security-auditor, test-engineer
-# 33 skills: git, orchestration, quality, planning, formats, specialized, agent-context,
-#   plus office-common (shared toolkit for xlsx/pptx/docx)
+# 34 skills: git, orchestration, quality, planning, formats, specialized, agent-context,
+#   plus office-common (shared toolkit for xlsx/pptx/docx) and changelog
+#   (replay of the last Claude Code CLI upgrade's CHANGELOG slice)
 # Note: sync and skills-import are project-local (.claude/skills/), not in system-configs
 EXPECTED_AGENT_COUNT = 8
-EXPECTED_SKILL_COUNT = 33
+EXPECTED_SKILL_COUNT = 34
 
 # Non-agent/command documentation files to skip
 NON_AGENT_FILES = [

--- a/system-configs/.claude/session_start_version_check.sh
+++ b/system-configs/.claude/session_start_version_check.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# Claude Code SessionStart Version Check Hook
+#
+# On every new session start, checks whether the Claude Code CLI has been
+# upgraded since the last session. If so, persists the relevant CHANGELOG
+# slice to $HOME/.claude/cache/last_upgrade.md so the /changelog skill can
+# replay "what's new" on demand. This hook emits NOTHING to the model or
+# terminal — the statusline handles the user-facing upgrade indicator
+# (✨ next to the version), and /changelog is run manually.
+#
+# State file : $HOME/.claude/last_seen_claude_version
+# Cache file : $HOME/.claude/cache/claude-code-changelog.md  (24h TTL)
+# Slice file : $HOME/.claude/cache/last_upgrade.md           (for /changelog)
+# Log file   : $HOME/.claude/logs/session_start_version_check.log
+#
+# Baseline: on first run (state file missing), seed with BASELINE_VERSION.
+#
+# Failure policy: every error path exits 0 with no stdout. Session start
+# MUST NEVER be blocked or delayed by this hook.
+#
+# TEST MODE:
+#   Pass --test as the first arg to use an isolated base directory. The
+#   base dir is $CLAUDE_TEST_DIR if set, else .tmp/session_start_check/.
+
+set +e  # never abort on errors
+
+# --- Argument parsing ---------------------------------------------------
+TEST_MODE=0
+if [[ "${1:-}" == "--test" ]]; then
+    TEST_MODE=1
+    shift
+fi
+
+# --- Paths --------------------------------------------------------------
+if [[ "$TEST_MODE" -eq 1 ]]; then
+    BASE_DIR="${CLAUDE_TEST_DIR:-.tmp/session_start_check}"
+else
+    BASE_DIR="$HOME/.claude"
+fi
+
+STATE_FILE="$BASE_DIR/last_seen_claude_version"
+CACHE_DIR="$BASE_DIR/cache"
+CACHE_FILE="$CACHE_DIR/claude-code-changelog.md"
+LOG_DIR="$BASE_DIR/logs"
+LOG_FILE="$LOG_DIR/session_start_version_check.log"
+
+# Baseline seeded on first run. Chosen to match the user's stated current
+# version at the time this hook was installed, so the first real session
+# after deploy demonstrates the feature.
+BASELINE_VERSION="2.1.100"
+
+CHANGELOG_URL="https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md"
+
+mkdir -p -m 700 "$BASE_DIR" "$CACHE_DIR" "$LOG_DIR" 2>/dev/null || true
+
+# --- Logging ------------------------------------------------------------
+log() {
+    local ts
+    ts=$(date '+%Y-%m-%d %H:%M:%S')
+    printf '[%s] %s\n' "$ts" "$1" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+# --- Atomic state write -------------------------------------------------
+write_state() {
+    local v="$1"
+    local tmp
+    tmp=$(mktemp "$BASE_DIR/.last_seen.XXXXXX" 2>/dev/null) || return 1
+    printf '%s\n' "$v" > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+    chmod 600 "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$STATE_FILE" 2>/dev/null || { rm -f "$tmp"; return 1; }
+    return 0
+}
+
+# --- Read stdin (SessionStart payload) ----------------------------------
+input=$(cat 2>/dev/null || echo "")
+
+# Filter on source == "startup" so resume/clear/compact don't re-greet
+source_val="startup"
+if [[ -n "$input" ]] && command -v jq >/dev/null 2>&1; then
+    parsed=$(printf '%s' "$input" | jq -r '.source // "startup"' 2>/dev/null)
+    [[ -n "$parsed" ]] && source_val="$parsed"
+fi
+
+if [[ "$source_val" != "startup" ]]; then
+    log "SKIP source=$source_val"
+    exit 0
+fi
+
+# --- Resolve current CLI version ---------------------------------------
+# SessionStart stdin payload does NOT include the CLI version (only
+# session_id, transcript_path, cwd, hook_event_name, source, model).
+# We have to call `claude --version` ourselves.
+current_version=""
+if command -v claude >/dev/null 2>&1; then
+    if command -v timeout >/dev/null 2>&1; then
+        raw=$(timeout 2 claude --version 2>/dev/null)
+    elif command -v gtimeout >/dev/null 2>&1; then
+        raw=$(gtimeout 2 claude --version 2>/dev/null)
+    else
+        raw=$(claude --version 2>/dev/null)
+    fi
+    current_version=$(printf '%s' "$raw" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+fi
+
+if [[ -z "$current_version" ]]; then
+    log "SKIP cannot resolve current version via claude --version"
+    exit 0
+fi
+
+# --- Read or seed stored version ---------------------------------------
+if [[ -f "$STATE_FILE" ]]; then
+    stored_version=$(tr -d '[:space:]' < "$STATE_FILE" 2>/dev/null)
+else
+    stored_version="$BASELINE_VERSION"
+    write_state "$stored_version"
+    log "INIT seeded state file with baseline $BASELINE_VERSION (current=$current_version)"
+fi
+
+if [[ -z "$stored_version" ]] || ! [[ "$stored_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log "WARN stored version invalid ('$stored_version'), resetting to baseline"
+    stored_version="$BASELINE_VERSION"
+fi
+
+# --- Equal version: nothing to do ---------------------------------------
+if [[ "$stored_version" == "$current_version" ]]; then
+    log "NOOP stored=$stored_version matches current"
+    exit 0
+fi
+
+# --- Detect upgrade vs downgrade ----------------------------------------
+newer=$(printf '%s\n%s\n' "$stored_version" "$current_version" | sort -V | tail -n1)
+if [[ "$newer" != "$current_version" ]]; then
+    # Downgrade: update file silently, no slice
+    write_state "$current_version"
+    log "DOWNGRADE stored=$stored_version current=$current_version, updated silently"
+    exit 0
+fi
+
+# --- Fetch CHANGELOG (with 24h cache) -----------------------------------
+need_fetch=1
+if [[ -f "$CACHE_FILE" ]]; then
+    cache_mtime=""
+    if stat -f %m "$CACHE_FILE" >/dev/null 2>&1; then
+        cache_mtime=$(stat -f %m "$CACHE_FILE" 2>/dev/null)   # BSD/macOS
+    elif stat -c %Y "$CACHE_FILE" >/dev/null 2>&1; then
+        cache_mtime=$(stat -c %Y "$CACHE_FILE" 2>/dev/null)   # GNU/Linux
+    fi
+    if [[ -n "$cache_mtime" ]]; then
+        now=$(date +%s)
+        age=$((now - cache_mtime))
+        if (( age < 86400 )); then
+            need_fetch=0
+        fi
+    fi
+fi
+
+if [[ "$need_fetch" -eq 1 ]]; then
+    if command -v curl >/dev/null 2>&1; then
+        tmp_fetch=$(mktemp "$CACHE_DIR/.changelog.XXXXXX" 2>/dev/null)
+        if [[ -n "$tmp_fetch" ]] && curl --max-time 3 --fail --silent \
+             "$CHANGELOG_URL" -o "$tmp_fetch" 2>/dev/null; then
+            mv -f "$tmp_fetch" "$CACHE_FILE" 2>/dev/null || rm -f "$tmp_fetch"
+            log "FETCH ok (cache refreshed)"
+        else
+            rm -f "$tmp_fetch" 2>/dev/null
+            log "FETCH_FAIL curl could not download CHANGELOG"
+            if [[ ! -f "$CACHE_FILE" ]]; then
+                exit 0
+            fi
+        fi
+    else
+        log "NO_CURL curl not available"
+        [[ -f "$CACHE_FILE" ]] || exit 0
+    fi
+fi
+
+# --- Slice changelog: print sections where stored < version <= current --
+# Uses a semver_cmp awk function to handle non-contiguous version sequences
+# (e.g., 2.1.101 → 2.1.98 with 99/100 skipped in the live CHANGELOG).
+slice=$(awk -v stored="$stored_version" -v current="$current_version" '
+function semver_cmp(a, b,    ap, bp, i, an, bn, ai, bi, mx) {
+    an = split(a, ap, ".")
+    bn = split(b, bp, ".")
+    mx = (an > bn ? an : bn)
+    for (i = 1; i <= mx; i++) {
+        ai = (i in ap) ? ap[i] + 0 : 0
+        bi = (i in bp) ? bp[i] + 0 : 0
+        if (ai < bi) return -1
+        if (ai > bi) return 1
+    }
+    return 0
+}
+BEGIN { printing = 0 }
+/^## [0-9]+\.[0-9]+\.[0-9]+/ {
+    v = $2
+    if (semver_cmp(v, stored) > 0 && semver_cmp(v, current) <= 0) {
+        printing = 1
+        print
+        next
+    } else {
+        printing = 0
+        next
+    }
+}
+printing { print }
+' "$CACHE_FILE" 2>/dev/null)
+
+# Empty slice: format mismatch or no versions in range
+if [[ -z "$(printf '%s' "$slice" | tr -d '[:space:]')" ]]; then
+    log "EMPTY_SLICE stored=$stored_version current=$current_version"
+    write_state "$current_version"
+    exit 0
+fi
+
+# --- Persist last upgrade slice for /changelog skill --------------------
+# Atomically write the from/to metadata + raw CHANGELOG slice so the
+# /changelog skill can replay "what's new" on demand. This hook emits
+# nothing to the model or terminal — the statusline surfaces the upgrade
+# indicator, and the user runs /changelog when they want the summary.
+# Best-effort: any failure here is silent.
+last_upgrade_file="$CACHE_DIR/last_upgrade.md"
+tmp_upgrade=$(mktemp "$CACHE_DIR/.last_upgrade.XXXXXX" 2>/dev/null)
+if [[ -n "$tmp_upgrade" ]]; then
+    {
+        printf -- '---\n'
+        printf 'from: %s\n' "$stored_version"
+        printf 'to: %s\n' "$current_version"
+        printf 'detected_at: %s\n' "$(date '+%Y-%m-%d %H:%M:%S %z')"
+        printf -- '---\n\n'
+        printf '%s\n' "$slice"
+    } > "$tmp_upgrade" 2>/dev/null \
+        && chmod 600 "$tmp_upgrade" 2>/dev/null \
+        && mv -f "$tmp_upgrade" "$last_upgrade_file" 2>/dev/null \
+        || rm -f "$tmp_upgrade" 2>/dev/null
+fi
+
+# --- Update state AFTER persisting slice --------------------------------
+write_state "$current_version"
+slice_lines=$(printf '%s\n' "$slice" | wc -l | tr -d ' ')
+log "UPGRADE stored=$stored_version → current=$current_version ($slice_lines lines)"
+
+exit 0

--- a/system-configs/.claude/session_start_version_check.sh
+++ b/system-configs/.claude/session_start_version_check.sh
@@ -96,6 +96,87 @@ semver_cmp() {
     }'
 }
 
+# --- Best-effort CHANGELOG cache refresh -------------------------------
+# Called unconditionally on every real session start (not only upgrades)
+# so that `/changelog <version>` works from first install and in
+# steady-state NOOP sessions, not just right after an upgrade. Respects
+# a 24h TTL so a warm cache is a pure no-op (no network). Returns 0 if
+# the cache is populated (fresh or stale-but-present), 1 if the cache
+# is absent and the fetch attempt also failed. NEVER calls `exit` —
+# callers decide whether cache absence is fatal for their path.
+refresh_changelog_cache() {
+    local need_fetch=1
+    local cache_mtime="" now age tmp_fetch fetch_size
+
+    if [[ -f "$CACHE_FILE" ]]; then
+        if stat -f %m "$CACHE_FILE" >/dev/null 2>&1; then
+            cache_mtime=$(stat -f %m "$CACHE_FILE" 2>/dev/null)   # BSD/macOS
+        elif stat -c %Y "$CACHE_FILE" >/dev/null 2>&1; then
+            cache_mtime=$(stat -c %Y "$CACHE_FILE" 2>/dev/null)   # GNU/Linux
+        fi
+        if [[ -n "$cache_mtime" ]]; then
+            now=$(date +%s)
+            age=$((now - cache_mtime))
+            if (( age < 86400 )); then
+                need_fetch=0
+            fi
+        fi
+    fi
+
+    if [[ "$need_fetch" -eq 0 ]]; then
+        return 0
+    fi
+
+    if ! command -v curl >/dev/null 2>&1; then
+        log "NO_CURL curl not available"
+        [[ -f "$CACHE_FILE" ]] && return 0 || return 1
+    fi
+
+    tmp_fetch=$(mktemp "$CACHE_DIR/.changelog.XXXXXX" 2>/dev/null)
+    if [[ -z "$tmp_fetch" ]]; then
+        log "FETCH_FAIL could not create tmp file in $CACHE_DIR"
+        [[ -f "$CACHE_FILE" ]] && return 0 || return 1
+    fi
+
+    # TLS hardening: force HTTPS, require TLS 1.2+. The fetched body is
+    # later rendered into the model context via /changelog, so this is a
+    # trusted input channel and any weakening here is a prompt-injection
+    # surface via DNS/MITM against raw.githubusercontent.com.
+    if ! curl --proto '=https' --tlsv1.2 \
+         --max-time 3 --fail --silent \
+         "$CHANGELOG_URL" -o "$tmp_fetch" 2>/dev/null; then
+        rm -f "$tmp_fetch" 2>/dev/null
+        log "FETCH_FAIL curl could not download CHANGELOG"
+        [[ -f "$CACHE_FILE" ]] && return 0 || return 1
+    fi
+
+    # Content sanity checks before promoting into the cache:
+    #   1. non-empty and <=2MB (CHANGELOG.md is tens of KB)
+    #   2. contains at least one `## <semver>` heading line
+    # On rejection, keep the previous cache (if any) untouched.
+    fetch_size=$(wc -c < "$tmp_fetch" 2>/dev/null | tr -d ' ')
+    if [[ -z "$fetch_size" ]] || [[ "$fetch_size" -eq 0 ]] || [[ "$fetch_size" -gt 2097152 ]]; then
+        log "FETCH_REJECT size=${fetch_size:-unknown} outside (0, 2MB]"
+        rm -f "$tmp_fetch" 2>/dev/null
+        [[ -f "$CACHE_FILE" ]] && return 0 || return 1
+    fi
+
+    if ! grep -qE '^##[[:space:]].*[0-9]+\.[0-9]+\.[0-9]+' "$tmp_fetch" 2>/dev/null; then
+        log "FETCH_REJECT no semver heading lines found in response body"
+        rm -f "$tmp_fetch" 2>/dev/null
+        [[ -f "$CACHE_FILE" ]] && return 0 || return 1
+    fi
+
+    if mv -f "$tmp_fetch" "$CACHE_FILE" 2>/dev/null; then
+        log "FETCH ok (cache refreshed, ${fetch_size} bytes)"
+        return 0
+    fi
+
+    rm -f "$tmp_fetch" 2>/dev/null
+    log "FETCH_FAIL could not move tmp into cache path"
+    [[ -f "$CACHE_FILE" ]] && return 0 || return 1
+}
+
 # --- Read stdin (SessionStart payload) ----------------------------------
 # Real mode: Claude Code pipes the JSON payload on stdin and closes it.
 # Test mode: only read stdin if it's a pipe/file, never if it's a TTY
@@ -159,6 +240,16 @@ if [[ -z "$current_version" ]]; then
     exit 0
 fi
 
+# --- Warm the CHANGELOG cache unconditionally --------------------------
+# Done BEFORE the state-file / NOOP / DOWNGRADE branches so that first
+# installs and steady-state sessions keep the cache populated for the
+# `/changelog <version>` skill. The helper respects a 24h TTL, so this
+# is a no-op when the cache is already warm. The return code is tracked
+# but not fatal here — callers that need the cache (upgrade slicing)
+# re-check `[[ -f "$CACHE_FILE" ]]` at their own branch.
+refresh_changelog_cache
+cache_refresh_status=$?
+
 # --- Read or seed stored version ---------------------------------------
 # First run: seed state with the currently-resolved version and exit
 # without producing a slice. The first REAL upgrade after init is what
@@ -201,67 +292,13 @@ if [[ "$cmp" == "-1" ]]; then
     exit 0
 fi
 
-# --- Fetch CHANGELOG (with 24h cache) -----------------------------------
-need_fetch=1
-if [[ -f "$CACHE_FILE" ]]; then
-    cache_mtime=""
-    if stat -f %m "$CACHE_FILE" >/dev/null 2>&1; then
-        cache_mtime=$(stat -f %m "$CACHE_FILE" 2>/dev/null)   # BSD/macOS
-    elif stat -c %Y "$CACHE_FILE" >/dev/null 2>&1; then
-        cache_mtime=$(stat -c %Y "$CACHE_FILE" 2>/dev/null)   # GNU/Linux
-    fi
-    if [[ -n "$cache_mtime" ]]; then
-        now=$(date +%s)
-        age=$((now - cache_mtime))
-        if (( age < 86400 )); then
-            need_fetch=0
-        fi
-    fi
-fi
-
-if [[ "$need_fetch" -eq 1 ]]; then
-    if command -v curl >/dev/null 2>&1; then
-        tmp_fetch=$(mktemp "$CACHE_DIR/.changelog.XXXXXX" 2>/dev/null)
-        # TLS hardening: force HTTPS, require TLS 1.2+. The fetched body is
-        # later rendered into the model context via /changelog, so this is a
-        # trusted input channel and any weakening here is a prompt-injection
-        # surface via DNS/MITM against raw.githubusercontent.com.
-        if [[ -n "$tmp_fetch" ]] && curl --proto '=https' --tlsv1.2 \
-             --max-time 3 --fail --silent \
-             "$CHANGELOG_URL" -o "$tmp_fetch" 2>/dev/null; then
-            # Content sanity checks before promoting into the cache:
-            #   1. non-empty and <=2MB (CHANGELOG.md is tens of KB)
-            #   2. contains at least one `## <semver>` heading line
-            # On rejection, keep the previous cache (if any) untouched.
-            fetch_size=$(wc -c < "$tmp_fetch" 2>/dev/null | tr -d ' ')
-            if [[ -z "$fetch_size" ]] || [[ "$fetch_size" -eq 0 ]] || [[ "$fetch_size" -gt 2097152 ]]; then
-                log "FETCH_REJECT size=${fetch_size:-unknown} outside (0, 2MB]"
-                rm -f "$tmp_fetch" 2>/dev/null
-                [[ -f "$CACHE_FILE" ]] || exit 0
-            elif ! grep -qE '^##[[:space:]].*[0-9]+\.[0-9]+\.[0-9]+' "$tmp_fetch" 2>/dev/null; then
-                log "FETCH_REJECT no semver heading lines found in response body"
-                rm -f "$tmp_fetch" 2>/dev/null
-                [[ -f "$CACHE_FILE" ]] || exit 0
-            else
-                if mv -f "$tmp_fetch" "$CACHE_FILE" 2>/dev/null; then
-                    log "FETCH ok (cache refreshed, ${fetch_size} bytes)"
-                else
-                    rm -f "$tmp_fetch" 2>/dev/null
-                    log "FETCH_FAIL could not move tmp into cache path"
-                    [[ -f "$CACHE_FILE" ]] || exit 0
-                fi
-            fi
-        else
-            rm -f "$tmp_fetch" 2>/dev/null
-            log "FETCH_FAIL curl could not download CHANGELOG"
-            if [[ ! -f "$CACHE_FILE" ]]; then
-                exit 0
-            fi
-        fi
-    else
-        log "NO_CURL curl not available"
-        [[ -f "$CACHE_FILE" ]] || exit 0
-    fi
+# --- Upgrade path: slice changelog --------------------------------------
+# refresh_changelog_cache already ran above. If it failed to produce any
+# cache at all, we cannot slice — bail without advancing stored_version
+# so the next session retries the fetch.
+if [[ "$cache_refresh_status" -ne 0 ]] || [[ ! -f "$CACHE_FILE" ]]; then
+    log "SKIP upgrade slice: CHANGELOG cache unavailable (stored=$stored_version current=$current_version)"
+    exit 0
 fi
 
 # --- Slice changelog: print sections where stored < version <= current --
@@ -299,10 +336,17 @@ BEGIN { printing = 0 }
 printing { print }
 ' "$CACHE_FILE" 2>/dev/null)
 
-# Empty slice: format mismatch or no versions in range
+# Empty slice: either the cache is stale (upstream CHANGELOG lags the
+# installed CLI), the live CHANGELOG skipped this version, or there's a
+# format mismatch. Do NOT advance stored_version here — if we did, we'd
+# permanently suppress /changelog for this upgrade even though the next
+# session's cache refresh could reveal the entries. Next session will
+# retry; if the cache eventually catches up, the slice will populate and
+# state will advance normally. Cost of retry is zero (just re-awk on the
+# existing cache) when the cache is still fresh, so the log-noise
+# trade-off is worth it to never lose an upgrade slice.
 if [[ -z "$(printf '%s' "$slice" | tr -d '[:space:]')" ]]; then
-    log "EMPTY_SLICE stored=$stored_version current=$current_version"
-    write_state "$current_version"
+    log "EMPTY_SLICE stored=$stored_version current=$current_version (state NOT advanced, will retry next session)"
     exit 0
 fi
 

--- a/system-configs/.claude/session_start_version_check.sh
+++ b/system-configs/.claude/session_start_version_check.sh
@@ -13,16 +13,17 @@
 # Slice file : $HOME/.claude/cache/last_upgrade.md           (for /changelog)
 # Log file   : $HOME/.claude/logs/session_start_version_check.log
 #
-# Baseline: on first run (state file missing), seed with BASELINE_VERSION.
+# Init: on first run (state file missing), the hook seeds the state file
+# with the currently-resolved version and exits without producing a slice.
+# The first real upgrade AFTER init is what triggers the first slice.
 #
 # Failure policy: every error path exits 0 with no stdout. Session start
-# MUST NEVER be blocked or delayed by this hook.
+# MUST NEVER be blocked or delayed by this hook. errexit is off by default
+# in bash — we rely on explicit per-operation guards rather than `set -e`.
 #
 # TEST MODE:
 #   Pass --test as the first arg to use an isolated base directory. The
 #   base dir is $CLAUDE_TEST_DIR if set, else .tmp/session_start_check/.
-
-set +e  # never abort on errors
 
 # --- Argument parsing ---------------------------------------------------
 TEST_MODE=0
@@ -44,14 +45,18 @@ CACHE_FILE="$CACHE_DIR/claude-code-changelog.md"
 LOG_DIR="$BASE_DIR/logs"
 LOG_FILE="$LOG_DIR/session_start_version_check.log"
 
-# Baseline seeded on first run. Chosen to match the user's stated current
-# version at the time this hook was installed, so the first real session
-# after deploy demonstrates the feature.
-BASELINE_VERSION="2.1.100"
-
 CHANGELOG_URL="https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md"
 
-mkdir -p -m 700 "$BASE_DIR" "$CACHE_DIR" "$LOG_DIR" 2>/dev/null || true
+# In test mode the parent (.tmp/) is shared with other tooling that expects
+# normal permissions; apply 700 only to the hook's own dirs. In real mode
+# BASE_DIR is $HOME/.claude and 700 is correct for the whole tree.
+if [[ "$TEST_MODE" -eq 1 ]]; then
+    mkdir -p "$(dirname "$BASE_DIR")" 2>/dev/null || true
+    mkdir -p "$BASE_DIR" "$CACHE_DIR" "$LOG_DIR" 2>/dev/null || true
+    chmod 700 "$BASE_DIR" "$CACHE_DIR" "$LOG_DIR" 2>/dev/null || true
+else
+    mkdir -p -m 700 "$BASE_DIR" "$CACHE_DIR" "$LOG_DIR" 2>/dev/null || true
+fi
 
 # --- Logging ------------------------------------------------------------
 log() {
@@ -72,7 +77,14 @@ write_state() {
 }
 
 # --- Read stdin (SessionStart payload) ----------------------------------
-input=$(cat 2>/dev/null || echo "")
+# In TEST_MODE we're invoked from a terminal where stdin is a TTY — an
+# unconditional `cat` blocks forever waiting for EOF. Skip the read entirely
+# in test mode and default to source=startup. In real mode, Claude Code
+# pipes a JSON payload on stdin that closes promptly.
+input=""
+if [[ "$TEST_MODE" -eq 0 ]]; then
+    input=$(cat 2>/dev/null || echo "")
+fi
 
 # Filter on source == "startup" so resume/clear/compact don't re-greet
 source_val="startup"
@@ -108,17 +120,29 @@ if [[ -z "$current_version" ]]; then
 fi
 
 # --- Read or seed stored version ---------------------------------------
-if [[ -f "$STATE_FILE" ]]; then
-    stored_version=$(tr -d '[:space:]' < "$STATE_FILE" 2>/dev/null)
-else
-    stored_version="$BASELINE_VERSION"
-    write_state "$stored_version"
-    log "INIT seeded state file with baseline $BASELINE_VERSION (current=$current_version)"
+# First run: seed state with the currently-resolved version and exit
+# without producing a slice. The first REAL upgrade after init is what
+# triggers the first slice — this avoids fabricating a fat
+# "upgrade from arbitrary-baseline → now" the first time the hook runs.
+if [[ ! -f "$STATE_FILE" ]]; then
+    if ! write_state "$current_version"; then
+        log "INIT_FAIL cannot write state file at $STATE_FILE (check perms on $BASE_DIR)"
+        exit 0
+    fi
+    log "INIT seeded state file with current=$current_version (no slice on first run)"
+    exit 0
 fi
 
+stored_version=$(tr -d '[:space:]' < "$STATE_FILE" 2>/dev/null)
+
+# Corrupt/empty state file: treat like a re-init so we don't carry forward
+# a garbage comparison. No slice produced on re-seed either.
 if [[ -z "$stored_version" ]] || ! [[ "$stored_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    log "WARN stored version invalid ('$stored_version'), resetting to baseline"
-    stored_version="$BASELINE_VERSION"
+    log "WARN stored version invalid ('$stored_version'), re-seeding with current=$current_version"
+    if ! write_state "$current_version"; then
+        log "RESEED_FAIL cannot rewrite state file at $STATE_FILE"
+    fi
+    exit 0
 fi
 
 # --- Equal version: nothing to do ---------------------------------------
@@ -157,10 +181,35 @@ fi
 if [[ "$need_fetch" -eq 1 ]]; then
     if command -v curl >/dev/null 2>&1; then
         tmp_fetch=$(mktemp "$CACHE_DIR/.changelog.XXXXXX" 2>/dev/null)
-        if [[ -n "$tmp_fetch" ]] && curl --max-time 3 --fail --silent \
+        # TLS hardening: force HTTPS, require TLS 1.2+. The fetched body is
+        # later rendered into the model context via /changelog, so this is a
+        # trusted input channel and any weakening here is a prompt-injection
+        # surface via DNS/MITM against raw.githubusercontent.com.
+        if [[ -n "$tmp_fetch" ]] && curl --proto '=https' --tlsv1.2 \
+             --max-time 3 --fail --silent \
              "$CHANGELOG_URL" -o "$tmp_fetch" 2>/dev/null; then
-            mv -f "$tmp_fetch" "$CACHE_FILE" 2>/dev/null || rm -f "$tmp_fetch"
-            log "FETCH ok (cache refreshed)"
+            # Content sanity checks before promoting into the cache:
+            #   1. non-empty and <=2MB (CHANGELOG.md is tens of KB)
+            #   2. contains at least one `## <semver>` heading line
+            # On rejection, keep the previous cache (if any) untouched.
+            fetch_size=$(wc -c < "$tmp_fetch" 2>/dev/null | tr -d ' ')
+            if [[ -z "$fetch_size" ]] || [[ "$fetch_size" -eq 0 ]] || [[ "$fetch_size" -gt 2097152 ]]; then
+                log "FETCH_REJECT size=${fetch_size:-unknown} outside (0, 2MB]"
+                rm -f "$tmp_fetch" 2>/dev/null
+                [[ -f "$CACHE_FILE" ]] || exit 0
+            elif ! grep -qE '^##[[:space:]].*[0-9]+\.[0-9]+\.[0-9]+' "$tmp_fetch" 2>/dev/null; then
+                log "FETCH_REJECT no semver heading lines found in response body"
+                rm -f "$tmp_fetch" 2>/dev/null
+                [[ -f "$CACHE_FILE" ]] || exit 0
+            else
+                if mv -f "$tmp_fetch" "$CACHE_FILE" 2>/dev/null; then
+                    log "FETCH ok (cache refreshed, ${fetch_size} bytes)"
+                else
+                    rm -f "$tmp_fetch" 2>/dev/null
+                    log "FETCH_FAIL could not move tmp into cache path"
+                    [[ -f "$CACHE_FILE" ]] || exit 0
+                fi
+            fi
         else
             rm -f "$tmp_fetch" 2>/dev/null
             log "FETCH_FAIL curl could not download CHANGELOG"
@@ -191,16 +240,20 @@ function semver_cmp(a, b,    ap, bp, i, an, bn, ai, bi, mx) {
     return 0
 }
 BEGIN { printing = 0 }
-/^## [0-9]+\.[0-9]+\.[0-9]+/ {
-    v = $2
-    if (semver_cmp(v, stored) > 0 && semver_cmp(v, current) <= 0) {
-        printing = 1
-        print
-        next
-    } else {
-        printing = 0
-        next
+/^## / {
+    # Extract the first semver anywhere in the heading so we tolerate
+    # `## 2.1.101`, `## [2.1.101]`, `## 2.1.101 (2026-04-10)`, etc. If the
+    # heading has no semver, treat it as a section break (printing = 0).
+    if (match($0, /[0-9]+\.[0-9]+\.[0-9]+/)) {
+        v = substr($0, RSTART, RLENGTH)
+        if (semver_cmp(v, stored) > 0 && semver_cmp(v, current) <= 0) {
+            printing = 1
+            print
+            next
+        }
     }
+    printing = 0
+    next
 }
 printing { print }
 ' "$CACHE_FILE" 2>/dev/null)
@@ -228,10 +281,16 @@ if [[ -n "$tmp_upgrade" ]]; then
         printf 'detected_at: %s\n' "$(date '+%Y-%m-%d %H:%M:%S %z')"
         printf -- '---\n\n'
         printf '%s\n' "$slice"
-    } > "$tmp_upgrade" 2>/dev/null \
-        && chmod 600 "$tmp_upgrade" 2>/dev/null \
-        && mv -f "$tmp_upgrade" "$last_upgrade_file" 2>/dev/null \
-        || rm -f "$tmp_upgrade" 2>/dev/null
+    } > "$tmp_upgrade" 2>/dev/null
+    # Explicit branch: either chmod+mv both succeed (tmp becomes the final
+    # file and is gone from the .XXXXXX path), or we clean up the tmp file.
+    if chmod 600 "$tmp_upgrade" 2>/dev/null \
+        && mv -f "$tmp_upgrade" "$last_upgrade_file" 2>/dev/null; then
+        :  # success: tmp is now at last_upgrade_file
+    else
+        rm -f "$tmp_upgrade" 2>/dev/null
+        log "SLICE_WRITE_FAIL could not persist $last_upgrade_file"
+    fi
 fi
 
 # --- Update state AFTER persisting slice --------------------------------

--- a/system-configs/.claude/session_start_version_check.sh
+++ b/system-configs/.claude/session_start_version_check.sh
@@ -76,21 +76,61 @@ write_state() {
     return 0
 }
 
+# --- Portable semver comparison -----------------------------------------
+# Prints -1 if $1 < $2, 0 if equal, 1 if $1 > $2. Used instead of
+# `sort -V` because BSD/macOS sort does not support -V and fails with a
+# stderr leak — the header's fail-silent contract forbids that.
+semver_cmp() {
+    awk -v a="$1" -v b="$2" '
+    BEGIN {
+        an = split(a, ap, ".")
+        bn = split(b, bp, ".")
+        mx = (an > bn ? an : bn)
+        for (i = 1; i <= mx; i++) {
+            ai = (i in ap) ? ap[i] + 0 : 0
+            bi = (i in bp) ? bp[i] + 0 : 0
+            if (ai < bi) { print -1; exit }
+            if (ai > bi) { print 1; exit }
+        }
+        print 0
+    }'
+}
+
 # --- Read stdin (SessionStart payload) ----------------------------------
-# In TEST_MODE we're invoked from a terminal where stdin is a TTY — an
-# unconditional `cat` blocks forever waiting for EOF. Skip the read entirely
-# in test mode and default to source=startup. In real mode, Claude Code
-# pipes a JSON payload on stdin that closes promptly.
+# Real mode: Claude Code pipes the JSON payload on stdin and closes it.
+# Test mode: only read stdin if it's a pipe/file, never if it's a TTY
+# (an unconditional `cat` from a terminal would hang waiting for EOF).
+# The TTY check lets piped input (echo ... | ./script --test) still
+# exercise the payload-parsing path during testing.
 input=""
-if [[ "$TEST_MODE" -eq 0 ]]; then
+if [[ "$TEST_MODE" -eq 0 ]] || [[ ! -t 0 ]]; then
     input=$(cat 2>/dev/null || echo "")
 fi
 
-# Filter on source == "startup" so resume/clear/compact don't re-greet
+# Filter on source == "startup" so resume/clear/compact don't re-greet.
+# When stdin has a payload we MUST determine .source. If jq is unavailable
+# we fall back to a tolerant regex parse; if the fallback also fails we
+# fail closed (exit 0, no slice) rather than silently defaulting to
+# "startup" — defaulting there would fire the upgrade check on every
+# resume/clear/compact event, which is exactly the wrong behavior.
 source_val="startup"
-if [[ -n "$input" ]] && command -v jq >/dev/null 2>&1; then
-    parsed=$(printf '%s' "$input" | jq -r '.source // "startup"' 2>/dev/null)
-    [[ -n "$parsed" ]] && source_val="$parsed"
+if [[ -n "$input" ]]; then
+    if command -v jq >/dev/null 2>&1; then
+        parsed=$(printf '%s' "$input" | jq -r '.source // empty' 2>/dev/null)
+    else
+        # Tolerant shell fallback: extract the first "source":"..." value,
+        # allowing arbitrary whitespace around the colon.
+        parsed=$(printf '%s' "$input" \
+            | grep -oE '"source"[[:space:]]*:[[:space:]]*"[^"]*"' \
+            | head -n1 \
+            | sed -E 's/.*"source"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
+    fi
+    if [[ -n "$parsed" ]]; then
+        source_val="$parsed"
+    else
+        log "SKIP could not parse .source from stdin payload (jq=$(command -v jq >/dev/null 2>&1 && echo yes || echo no))"
+        exit 0
+    fi
 fi
 
 if [[ "$source_val" != "startup" ]]; then
@@ -152,9 +192,10 @@ if [[ "$stored_version" == "$current_version" ]]; then
 fi
 
 # --- Detect upgrade vs downgrade ----------------------------------------
-newer=$(printf '%s\n%s\n' "$stored_version" "$current_version" | sort -V | tail -n1)
-if [[ "$newer" != "$current_version" ]]; then
-    # Downgrade: update file silently, no slice
+# Uses the portable semver_cmp helper instead of `sort -V` (GNU-only).
+cmp=$(semver_cmp "$current_version" "$stored_version")
+if [[ "$cmp" == "-1" ]]; then
+    # Downgrade: update state silently, no slice
     write_state "$current_version"
     log "DOWNGRADE stored=$stored_version current=$current_version, updated silently"
     exit 0

--- a/system-configs/.claude/settings.json
+++ b/system-configs/.claude/settings.json
@@ -104,6 +104,17 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/.claude/session_start_version_check.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/system-configs/.claude/skills/changelog/SKILL.md
+++ b/system-configs/.claude/skills/changelog/SKILL.md
@@ -65,16 +65,23 @@ user wants to see every bullet.
 
 1. Skip `last_upgrade.md` entirely.
 2. Read the cached full changelog at `$HOME/.claude/cache/claude-code-changelog.md`
-   (maintained by the hook, 24h TTL).
+   (maintained by the hook).
 3. **Do not fetch.** This skill is read-only with respect to the cache —
    the hook owns network I/O so TLS hardening, sanity checks, and error
-   handling live in one place. If the cache is missing or older than 24
-   hours, tell the user: *"The cached CHANGELOG is missing or stale. Start
-   a new Claude Code session to refresh it (the SessionStart hook will
-   refetch), then re-run `/changelog <version>`."* Do not run `curl`.
-4. Extract the `## <version>` section (everything from `## 2.1.99` up to the
-   next `##` heading) and summarize it with the same Features/Improvements/Fixes
-   structure as the default mode.
+   handling live in one place. If the cache file does not exist, tell
+   the user: *"The cached CHANGELOG is missing. Start a new Claude Code
+   session to refresh it — the SessionStart hook will refetch — then
+   re-run `/changelog <version>`."* Do not run `curl`. The hook refreshes
+   the cache on session start when the file is more than 24h old, so
+   "start a new session" is the user-visible refresh mechanism. The
+   skill itself has no way to inspect the cache's age (Read gives
+   contents, not mtime), so it must not make freshness claims.
+4. Extract the section for the requested version. Scan `##` headings
+   and pull the first semver found in each (so `## 2.1.99`,
+   `## [2.1.99]`, and `## 2.1.99 (2026-04-10)` all match version
+   `2.1.99` — matching the hook's own slicer). Take everything from the
+   matching heading up to the next `##` heading and summarize it with
+   the same Features/Improvements/Fixes structure as the default mode.
 5. If the requested version is not present in the CHANGELOG, say so — do not
    invent content.
 

--- a/system-configs/.claude/skills/changelog/SKILL.md
+++ b/system-configs/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: changelog
+description: Replay the Claude Code CHANGELOG entries from the most recent CLI upgrade. Use when the user wants to revisit "what's new" after the session-start greeting has scrolled away, or asks things like "what changed in the last upgrade", "show me the changelog", "what did I just upgrade into".
+argument-hint: "[--full|<version>]"
+category: workflow
+---
+
+# /changelog
+
+## Usage
+
+```bash
+/changelog              # Summarize the last upgrade's changelog slice
+/changelog --full       # Show the raw CHANGELOG slice without summarization
+/changelog <version>    # Show a specific version's section (e.g. /changelog 2.1.99)
+```
+
+## Description
+
+Replays the Claude Code CHANGELOG entries captured the last time the CLI was
+upgraded, so the user can revisit "what's new" on demand. Complementary to the
+SessionStart version-check hook: the hook shows the greeting once at startup,
+this skill lets the user ask for it again at any point in the session.
+
+## Behavior
+
+### Default (`/changelog`)
+
+1. **Read the persisted slice** at `$HOME/.claude/cache/last_upgrade.md`.
+   This file is written by `~/.claude/session_start_version_check.sh` whenever
+   a real upgrade is detected. Format:
+
+   ```text
+   ---
+   from: <prev version>
+   to: <current version>
+   detected_at: <timestamp>
+   ---
+
+   ## <current version>
+   ... raw CHANGELOG entries ...
+   ```
+
+2. **If the file exists**, parse the YAML header (`from`, `to`, `detected_at`)
+   and the body (the raw changelog slice), then present:
+
+   - A one-line header: `Claude Code <from> → <to> (upgraded <detected_at>)`
+   - A themed summary: **Features**, **Improvements**, **Fixes**. 5–8 bullets
+     total. Prioritize user-facing changes over internal fixes — match the
+     style the session-start greeting uses.
+   - A one-line footer: `Reply '/changelog --full' to see the raw entries.`
+
+3. **If the file does NOT exist**, no upgrade has been observed on this
+   machine since the hook was installed. Report that plainly. Do not fabricate
+   entries. Offer: "Run `claude --version` and I can look up that version's
+   changelog section directly if you'd like."
+
+### `--full` mode
+
+Print the raw body of `$HOME/.claude/cache/last_upgrade.md` verbatim (strip the
+YAML header, keep the changelog markdown). No summarization. Useful when the
+user wants to see every bullet.
+
+### Specific version (`/changelog 2.1.99`)
+
+1. Skip `last_upgrade.md` entirely.
+2. Read the cached full changelog at `$HOME/.claude/cache/claude-code-changelog.md`
+   (also maintained by the hook, 24h TTL).
+3. If the cache is missing or older than 24 hours, refetch from
+   `https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`
+   using `curl --max-time 3 --fail --silent`. On fetch failure, fall back to
+   whatever is cached; if nothing is cached, report the network error plainly.
+4. Extract the `## <version>` section (everything from `## 2.1.99` up to the
+   next `##` heading) and summarize it with the same Features/Improvements/Fixes
+   structure as the default mode.
+5. If the requested version is not present in the CHANGELOG, say so — do not
+   invent content.
+
+## Implementation notes for the model
+
+- Use the **Read** tool for `~/.claude/cache/last_upgrade.md` and
+  `~/.claude/cache/claude-code-changelog.md`. Both are plain text.
+- Use **Bash** only when a fetch is actually needed (specific-version mode
+  with stale/missing cache). Never fetch on the default path — the hook
+  already maintains the cache.
+- Never write to `~/.claude/cache/last_upgrade.md`. This skill is read-only
+  with respect to hook state. The hook owns that file.
+- When summarizing, group bullets by theme and cap at 8 bullets. If the slice
+  contains many fixes, collapse similar ones into a single bullet
+  (e.g. "Several `/resume` picker fixes" rather than listing each).
+- Be faithful: only summarize entries that appear in the source. Do not
+  extrapolate from version numbers.
+
+## Expected Output
+
+### Default mode — slice exists
+
+```text
+User: /changelog
+
+Claude Code 2.1.100 → 2.1.101 (upgraded 2026-04-10 09:14:22 -0700)
+
+Features
+  - /team-onboarding generates a teammate ramp-up guide from local usage
+  - OS CA certificate store trusted by default for enterprise TLS proxies
+
+Improvements
+  - Tool-not-available, rate-limit, and refusal errors now explain what
+    happened and how to proceed
+  - /context free-space accounting now matches the header percentage
+
+Fixes
+  - --resume/--continue no longer loses context on large sessions
+  - Hardcoded 5-minute request timeout removed; API_TIMEOUT_MS is honored
+  - permissions.deny now overrides PreToolUse hook "ask" decisions (security)
+
+Reply '/changelog --full' to see the raw entries.
+```
+
+### Default mode — no upgrade recorded yet
+
+```text
+User: /changelog
+
+No upgrade has been recorded on this machine yet. The session-start
+version-check hook writes ~/.claude/cache/last_upgrade.md the first time
+it sees a version change after install.
+
+If you want a specific version's changelog, try /changelog <version>
+(e.g. /changelog 2.1.101).
+```
+
+### Specific version mode
+
+```text
+User: /changelog 2.1.99
+
+Claude Code 2.1.99 (from cached CHANGELOG)
+
+Features
+  - ...
+
+(summarized from anthropics/claude-code CHANGELOG.md)
+```
+
+## Notes
+
+- The cache and slice files live under `~/.claude/cache/` and are owned by
+  `session_start_version_check.sh`.
+- Slice is updated only when the hook detects a true upgrade (not on
+  downgrades, not on equal-version boots).
+- This skill does no network work on the default path — it is safe to run
+  offline as long as an upgrade has been observed at least once.

--- a/system-configs/.claude/skills/changelog/SKILL.md
+++ b/system-configs/.claude/skills/changelog/SKILL.md
@@ -65,11 +65,13 @@ user wants to see every bullet.
 
 1. Skip `last_upgrade.md` entirely.
 2. Read the cached full changelog at `$HOME/.claude/cache/claude-code-changelog.md`
-   (also maintained by the hook, 24h TTL).
-3. If the cache is missing or older than 24 hours, refetch from
-   `https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`
-   using `curl --max-time 3 --fail --silent`. On fetch failure, fall back to
-   whatever is cached; if nothing is cached, report the network error plainly.
+   (maintained by the hook, 24h TTL).
+3. **Do not fetch.** This skill is read-only with respect to the cache —
+   the hook owns network I/O so TLS hardening, sanity checks, and error
+   handling live in one place. If the cache is missing or older than 24
+   hours, tell the user: *"The cached CHANGELOG is missing or stale. Start
+   a new Claude Code session to refresh it (the SessionStart hook will
+   refetch), then re-run `/changelog <version>`."* Do not run `curl`.
 4. Extract the `## <version>` section (everything from `## 2.1.99` up to the
    next `##` heading) and summarize it with the same Features/Improvements/Fixes
    structure as the default mode.
@@ -80,11 +82,14 @@ user wants to see every bullet.
 
 - Use the **Read** tool for `~/.claude/cache/last_upgrade.md` and
   `~/.claude/cache/claude-code-changelog.md`. Both are plain text.
-- Use **Bash** only when a fetch is actually needed (specific-version mode
-  with stale/missing cache). Never fetch on the default path — the hook
-  already maintains the cache.
-- Never write to `~/.claude/cache/last_upgrade.md`. This skill is read-only
-  with respect to hook state. The hook owns that file.
+- **Never run `curl` or any other network fetch from this skill.** The
+  SessionStart version-check hook owns the cache and all network I/O —
+  TLS hardening, timeouts, content sanity checks, and error logging all
+  live there. Duplicating fetch logic here would drift from the hook's
+  hardening and split the attack surface across two places.
+- Never write to `~/.claude/cache/last_upgrade.md` or
+  `~/.claude/cache/claude-code-changelog.md`. This skill is strictly
+  read-only with respect to hook state. The hook owns those files.
 - When summarizing, group bullets by theme and cap at 8 bullets. If the slice
   contains many fixes, collapse similar ones into a single bullet
   (e.g. "Several `/resume` picker fixes" rather than listing each).

--- a/system-configs/.claude/skills/resolve-comments/SKILL.md
+++ b/system-configs/.claude/skills/resolve-comments/SKILL.md
@@ -211,12 +211,21 @@ STEP 5: Finalize
     OUTPUT: "Saved {count} skipped issues for /ship-it acknowledgment"
 
   IF: fixes applied
-    ASK_USER:
-      question: "Commit, push, and post resolution to PR #{pr}? ({fix_count} fixes on {current_branch})"
-      options:
-        - "Yes - commit, push, and post @coderabbitai resolve"
-        - "No - stop after local changes only"
-    WAIT: for user response
+    USE: AskUserQuestion tool with:
+      questions:
+        - header: "Commit+push"
+          question: "Commit, push, and post resolution to PR #{pr}? ({fix_count} fixes on {current_branch})"
+          multiSelect: false
+          options:
+            - label: "Commit, push, post"
+              description: "Stage tracked files, commit, push, and reply @coderabbitai resolve on each thread"
+            - label: "Local only"
+              description: "Keep working-tree changes as-is; no commit, push, or PR comment"
+    WAIT: for the AskUserQuestion response
+    MAP: selected label to decision
+      - "Commit, push, post" → proceed with commit+push+PR comment flow
+      - "Local only" → skip commit/push/comment and end after finalize
+      - Any "Other" freeform response → treat as "Local only" unless it clearly authorizes the commit+push flow
 
     IF: user selected "Yes"
       VALIDATE: fix_count is numeric integer > 0
@@ -233,7 +242,21 @@ STEP 5: Finalize
             END
         IF: unexpected files detected
           OUTPUT: "Warning: detected changes to files not in fix list"
-          ASK_USER: whether to include or exclude unexpected files
+          USE: AskUserQuestion tool with:
+            questions:
+              - header: "Extra files"
+                question: "Detected changes to files not in the fix list. How should they be handled?"
+                multiSelect: false
+                options:
+                  - label: "Exclude extras (Recommended)"
+                    description: "Stage only files associated with resolved issues; leave extras uncommitted"
+                  - label: "Include all"
+                    description: "Stage every modified tracked file in this commit"
+          WAIT: for the AskUserQuestion response
+          MAP: selected label to decision
+            - "Exclude extras (Recommended)" → git add only the reconciled list
+            - "Include all" → expand modified_files to the full `git diff --name-only`
+            - Any "Other" freeform response → default to exclude extras (safer)
       RUN: git add {modified_files} (never use git add -A)
       RUN: git commit -m "fix: resolve CodeRabbit feedback ({fix_count} issues)"
       RUN: git push
@@ -426,12 +449,21 @@ STEP 3: Apply fixes
 
 STEP 4: Finalize
   IF: fixes applied AND fix_count > 0
-    ASK_USER:
-      question: "Commit {fix_count} fixes to the repository?"
-      options:
-        - "Yes - commit changes"
-        - "No - keep changes uncommitted"
-    WAIT: for user response
+    USE: AskUserQuestion tool with:
+      questions:
+        - header: "Commit?"
+          question: "Commit {fix_count} fixes to the repository?"
+          multiSelect: false
+          options:
+            - label: "Commit fixes"
+              description: "Stage the modified files and create a local commit (no push)"
+            - label: "Keep uncommitted"
+              description: "Leave fixes as working-tree changes; caller will commit later"
+    WAIT: for the AskUserQuestion response
+    MAP: selected label to decision
+      - "Commit fixes" → stage + commit flow below
+      - "Keep uncommitted" → skip commit, preserve changes
+      - Any "Other" freeform response → default to keep uncommitted
 
     IF: user selected "Yes"
       RECONCILE: modified_files list against git diff --name-only
@@ -527,13 +559,24 @@ IF: --dry-run flag
 IF: --auto flag
   PROCEED: with all recommended fixes
 ELSE:
-  ASK_USER:
-    question: "How would you like to proceed?"
-    options:
-      - "Approve all fixes ({fix_count} issues)"
-      - "Review each issue individually"
-      - "Skip all"
-  WAIT: for user response
+  USE: AskUserQuestion tool with:
+    questions:
+      - header: "Triage"
+        question: "How would you like to proceed with the {fix_count + skip_count} issues?"
+        multiSelect: false
+        options:
+          - label: "Approve all fixes (Recommended)"
+            description: "Apply all {fix_count} recommended FIX actions; the {skip_count} SKIP items go to the ignored list"
+          - label: "Review each issue"
+            description: "Walk through every issue individually and decide per issue"
+          - label: "Skip all"
+            description: "Do not apply any fixes; record everything as skipped"
+  WAIT: for the AskUserQuestion response
+  MAP: selected label to decision
+    - "Approve all fixes (Recommended)" → apply all FIX-recommended issues, move SKIP items to skipped_issues
+    - "Review each issue" → enter the per-issue review loop below
+    - "Skip all" → record every issue in skipped_issues with reason "user skipped all during triage"
+    - Any "Other" freeform response → treat as "Review each issue" so the user can choose per issue
 ```
 
 ### Apply Fixes
@@ -589,18 +632,23 @@ FOR_EACH: skipped issue
   USE: auto-generated skip_category and reason from evaluation phase
   STORE: issue with category in skipped_issues
 
-IF: user selected "Review each issue individually"
+IF: user selected "Review each issue"
   FOR_EACH: issue in issues
     DISPLAY: issue details (source, description, recommendation)
-    ASK_USER:
-      question: "Resolve this issue?"
-      options:
-        - "Yes - apply fix"
-        - "No - skip"
-    WAIT: for user response
-    IF: user selected "Yes - apply fix"
+    USE: AskUserQuestion tool with:
+      questions:
+        - header: "This issue"
+          question: "Resolve this issue? ({issue.location} — {issue.summary})"
+          multiSelect: false
+          options:
+            - label: "Apply fix"
+              description: "Apply the recommended fix for this single issue"
+            - label: "Skip"
+              description: "Record this issue in the skipped list with a user-skipped reason"
+    WAIT: for the AskUserQuestion response
+    IF: user selected "Apply fix"
       ADD: issue to approved_issues
-    ELSE:
+    ELSE:  # "Skip" or "Other" freeform
       IF: issue.skip_category is undefined (e.g., originally recommended as FIX)
         SET: issue.skip_category = "user-skipped"
         SET: issue.reason = "User chose to skip during individual review"
@@ -702,8 +750,10 @@ Summary: 4 to fix, 1 to skip
 
 ## Context Compatibility
 
-This skill requires user interaction (ASK_USER prompts) and MUST NOT use `context: fork`.
-When invoked from a forked context, callers MUST pass `--auto` to bypass prompts.
+This skill requires user interaction via the **AskUserQuestion** tool and MUST NOT
+use `context: fork`. Forked contexts cannot show AskUserQuestion prompts to the
+user, so any caller that runs this skill in a forked context MUST pass `--auto`
+to bypass the prompts.
 
 | Caller | Flag Required | Reason |
 |--------|---------------|--------|

--- a/system-configs/.claude/skills/resolve-comments/SKILL.md
+++ b/system-configs/.claude/skills/resolve-comments/SKILL.md
@@ -227,7 +227,7 @@ STEP 5: Finalize
       - "Local only" → skip commit/push/comment and end after finalize
       - Any "Other" freeform response → treat as "Local only" unless it clearly authorizes the commit+push flow
 
-    IF: user selected "Yes"
+    IF: user selected "Commit, push, post"
       VALIDATE: fix_count is numeric integer > 0
         IF: fix_count == 0
           OUTPUT: "No fixes to commit. Skipping git operations."
@@ -465,7 +465,7 @@ STEP 4: Finalize
       - "Keep uncommitted" → skip commit, preserve changes
       - Any "Other" freeform response → default to keep uncommitted
 
-    IF: user selected "Yes"
+    IF: user selected "Commit fixes"
       RECONCILE: modified_files list against git diff --name-only
       RUN: git add {modified_files} (never use git add -A)
       RUN: git commit -m "fix: resolve review feedback ({fix_count} issues)"


### PR DESCRIPTION
## Summary

Add a SessionStart hook that captures the CHANGELOG slice of each Claude Code CLI upgrade, and a read-only `/changelog` skill that replays "what's new" on demand. Refactor `sync.sh` to drive hook-script deployment from a single declarative list.

## Changes

- **`session_start_version_check.sh`** (new): resolves `claude --version`, maintains a 24h-cached CHANGELOG at `~/.claude/cache/claude-code-changelog.md`, slices sections in `(stored, current]` using an awk `semver_cmp` function, and atomically writes `~/.claude/cache/last_upgrade.md` when a real upgrade is detected. Fail-silent, 5s hook timeout, emits nothing to stdout.
- **`/changelog` skill** (new): read-only replay of the persisted slice. Default mode summarizes Features/Improvements/Fixes; `--full` prints the raw body; `/changelog <version>` reads the cached full CHANGELOG. Never fetches from the skill — the hook owns all network I/O.
- **`settings.json`**: new `SessionStart` hook entry wiring the script at `${HOME}/.claude/session_start_version_check.sh` with a 5s timeout.
- **`sync.sh`**: per-script cp/chmod/syntax-check blocks replaced by a single loop driven by `RUNTIME_HOOK_SCRIPTS="statusline.sh exit_hook.sh session_start_version_check.sh"`. Dry-run preview and synced-settings summary read from the same list. Validation uses `bash -n` (all shipped hooks are `#!/bin/bash` and use bash-only constructs — `sh -n` would false-positive on Linux dash).
- **Docs**: `docs/setup/AUDIO_HOOK_README.md` gains a "Session Version-Check Hook" section (paths, failure policy, test mode). `README.md` sync output and repo-tree snippet updated.

## Context

Built in response to wanting to revisit "what's new" after the Claude Code startup greeting scrolls away. The hook captures the slice passively at session start; the skill is a zero-network replay for the user to invoke on demand.

## Review findings addressed

Second commit (`52989ed`) addresses all 12 findings from a local code review of the first commit — 2 HIGH, 5 MEDIUM, 5 LOW. Highlights:

- **HIGH**: `sync.sh` now uses `bash -n` instead of `sh -n` (dash would reject the new hook's bashisms and abort `/sync` on Linux).
- **HIGH**: Removed hardcoded `BASELINE_VERSION="2.1.100"`. First run now seeds state with the currently-resolved version and exits without a slice, so new users don't get a fabricated 50-version "fake upgrade" on their first session.
- **MED**: Added `--proto '=https' --tlsv1.2` to the curl fetch, plus size (<=2MB) and `## <semver>` content sanity checks on the response body before promoting into cache. The body flows into model context via `/changelog`, so the fetch is a trusted input channel.
- **MED**: `--test` mode no longer hangs on stdin `cat`, no longer forces mode 700 on the shared `.tmp/` parent.
- **MED**: Robust awk semver extraction via `match()`/`substr()` — tolerates `## [2.1.101]`, `## 2.1.101 (date)`, etc.
- **LOW**: `/changelog` skill is now strictly read-only w.r.t. the cache (no duplicated fetch/TLS logic).

## Testing

- `bash -n` clean on both shell scripts
- Manual `--test` runs of the hook exercise all four paths:
  - **INIT**: state missing → seeds current version, no slice written
  - **NOOP**: stored == current → logs, exits
  - **UPGRADE**: 2.1.98 → 2.1.101 against live CHANGELOG → 48-line slice written (219 KB fetch passed TLS + sanity checks)
  - **RESEED**: corrupt state file → re-seeds with current, no slice
- Full test suite: **19/19 passing**
- Markdown lint: **0 violations** across 91 files
- `sync.sh --dry-run` lists all three hook scripts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /changelog command (full and per-version modes) and unified AskUser-based review prompts.
  * New session-start hook that detects CLI version changes, caches changelog slices, and surfaces last-upgrade info; sync now reports 34 skills and always enumerates runtime hooks.

* **Documentation**
  * Deployment and hook docs updated with SessionStart behavior, timeout, test mode, and settings examples.

* **Tests**
  * Expected skill count updated to 34.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->