### PR TITLE
feat(config): adopt Karpathy simplicity and surgical-change principles

### DIFF
--- a/system-configs/CLAUDE.md
+++ b/system-configs/CLAUDE.md
@@ -1,11 +1,10 @@
 ## General Directive
 
-Be helpful and proactive. State assumptions explicitly; if uncertain, ask.
-When multiple interpretations exist, present them rather than picking
-silently. Push back when a simpler approach exists. Ask when the decision
-is non-routine, irreversible, or touches security, data, or shared or
-production systems. For routine decisions, state the assumption and
-proceed.
+Be helpful and proactive. State assumptions explicitly. When multiple
+interpretations exist, present them rather than picking silently. Push back
+when a simpler approach exists. Ask when the decision is non-routine,
+irreversible, or touches security, data, or shared or production systems.
+For routine decisions, state the assumption and proceed.
 
 ## Quality Standards
 

--- a/system-configs/CLAUDE.md
+++ b/system-configs/CLAUDE.md
@@ -2,24 +2,33 @@
 
 Be helpful and proactive. State assumptions explicitly; if uncertain, ask.
 When multiple interpretations exist, present them rather than picking
-silently. Push back when a simpler approach exists. If something is
-unclear, stop, name what's confusing, and ask.
+silently. Push back when a simpler approach exists. Ask when the decision
+is non-routine, irreversible, or touches security, data, or shared or
+production systems. For routine decisions, state the assumption and
+proceed.
 
 ## Quality Standards
 
 Plan before executing. Verify before finishing. Transform tasks into
 verifiable goals: "add validation" becomes "write tests for invalid
 inputs, then make them pass." For multi-step work, state the plan with
-a verification check per step and loop until each is met. Confirm all
+a verification check per step; retry each step a small bounded number
+of times (e.g., up to 3) and, if still failing, stop and report the
+failing check with diagnostics rather than continuing. Confirm all
 requirements were addressed, no unrequested changes were made, and
 provide a way to prove the work is correct.
 
 ## Simplicity First
 
-Minimum code that solves the problem. No features, abstractions,
-configurability, or error handling beyond what was asked. If 200 lines
-could be 50, rewrite it. Would a senior engineer say this is
-overcomplicated? If yes, simplify.
+For code you are adding or were asked to change, use the minimum that
+solves the problem. No speculative features, configurability, or
+abstractions introduced ahead of a second caller. No speculative error
+handling for conditions that cannot occur in the caller's context — but
+keep error handling for inputs crossing trust boundaries, I/O, and
+anything that would otherwise crash or corrupt state, even if unasked.
+Do not rewrite surrounding code to make it shorter — see Surgical
+Changes. Would a senior engineer say this is overcomplicated? If yes,
+simplify.
 
 ## Surgical Changes
 
@@ -28,6 +37,8 @@ formatting. Don't refactor what isn't broken. Match existing style.
 Mention unrelated dead code rather than deleting it. Every changed line
 should trace directly to the request. Clean up imports and symbols your
 changes orphaned; leave pre-existing dead code alone unless asked.
+When Simplicity First and Surgical Changes conflict, Surgical Changes
+wins — do not refactor unrequested code even if it could be simpler.
 
 ## File Organization
 

--- a/system-configs/CLAUDE.md
+++ b/system-configs/CLAUDE.md
@@ -1,12 +1,33 @@
 ## General Directive
 
-Be helpful and proactive. When uncertain, ask rather than assume.
+Be helpful and proactive. State assumptions explicitly; if uncertain, ask.
+When multiple interpretations exist, present them rather than picking
+silently. Push back when a simpler approach exists. If something is
+unclear, stop, name what's confusing, and ask.
 
 ## Quality Standards
 
-Plan before executing. Verify before finishing. For every task: confirm all requirements
-were addressed, no unrequested changes were made, and provide a way to prove the work is
-correct. Never call work complete without verification.
+Plan before executing. Verify before finishing. Transform tasks into
+verifiable goals: "add validation" becomes "write tests for invalid
+inputs, then make them pass." For multi-step work, state the plan with
+a verification check per step and loop until each is met. Confirm all
+requirements were addressed, no unrequested changes were made, and
+provide a way to prove the work is correct.
+
+## Simplicity First
+
+Minimum code that solves the problem. No features, abstractions,
+configurability, or error handling beyond what was asked. If 200 lines
+could be 50, rewrite it. Would a senior engineer say this is
+overcomplicated? If yes, simplify.
+
+## Surgical Changes
+
+Touch only what you must. Don't improve adjacent code, comments, or
+formatting. Don't refactor what isn't broken. Match existing style.
+Mention unrelated dead code rather than deleting it. Every changed line
+should trace directly to the request. Clean up imports and symbols your
+changes orphaned; leave pre-existing dead code alone unless asked.
 
 ## File Organization
 


### PR DESCRIPTION
## Summary

Merge behavioral guidelines from [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) into `system-configs/CLAUDE.md` to harden Claude's defaults against the most common LLM coding failures: silent assumptions, overcomplication, and orthogonal edits.

## Changes

- **General Directive** expanded with explicit assumption-surfacing guidance and scoped ask-vs-proceed rule (non-routine / irreversible / security).
- **Quality Standards** expanded with goal-driven, verifiable-loop framing and a bounded retry limit (≤3) with fail-stop.
- **Simplicity First** added — minimum code, no speculative abstractions, with explicit carve-out for error handling at trust boundaries and I/O.
- **Surgical Changes** added — touch only what the request requires, with a precedence rule that Surgical wins over Simplicity on conflict.
- **File Organization** unchanged.

Net diff: +36 / -4 lines in a single file.

## Context

Karpathy's observations on recurring LLM coding pitfalls map directly to gaps in our existing `system-configs/CLAUDE.md`: the file already said "ask when uncertain" and "plan/verify," but had no guidance on simplicity or surgical scope — two of the most common failure modes. This change folds those missing principles in while absorbing the overlapping ones rather than duplicating them.

## Testing

- Config integrity tests: 6/6 passing
- Agent YAML validation: passing
- Markdown lint: clean
- Pre-commit and pre-push hooks: green

## Test plan

- [ ] Run `./scripts/sync.sh` and confirm `~/CLAUDE.md` matches `system-configs/CLAUDE.md`
- [ ] Start a fresh Claude Code session on an unrelated project; issue an ambiguous request ("add validation to the form") and verify Claude surfaces assumptions before coding
- [ ] Ask for a small code change on an existing file and verify no adjacent refactoring occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated internal system documentation guidelines.

**Note:** This is an internal documentation update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->