### PR TITLE
docs: add AskUserQuestion tool guidance to CLAUDE.md and interface guidelines

### DIFF
--- a/docs/ux/interface-guidelines.md
+++ b/docs/ux/interface-guidelines.md
@@ -263,6 +263,35 @@ For operations with continuous progress:
 - Best practice recommendations
 - Optional optimizations
 
+### Clarification and User Questions
+
+When Claude needs to ask the user a question or request clarification, it must use the `AskUserQuestion` tool rather than embedding the question in plain text responses. This ensures questions are surfaced clearly and the user can provide focused answers.
+
+#### When to Use AskUserQuestion
+
+- Ambiguous requests with multiple valid interpretations
+- Non-routine decisions that require user input before proceeding
+- Irreversible or high-impact operations needing explicit confirmation
+- Missing information required to complete the task
+
+#### When Not to Use AskUserQuestion
+
+- Routine decisions where an assumption can be stated and work can proceed
+- Questions whose answer can be inferred from context
+- Situations where the General Directive applies: state the assumption and proceed
+
+#### Example
+
+```text
+# Correct: use AskUserQuestion tool
+[AskUserQuestion] Which environment should I target: staging or production?
+
+# Incorrect: embedding the question in plain text response
+I can proceed once you tell me whether to target staging or production.
+```
+
+This requirement is defined in the General Directive section of `system-configs/CLAUDE.md`.
+
 ### Audio Feedback Integration
 
 #### Audio Cue Standards

--- a/system-configs/CLAUDE.md
+++ b/system-configs/CLAUDE.md
@@ -4,7 +4,9 @@ Be helpful and proactive. State assumptions explicitly. When multiple
 interpretations exist, present them rather than picking silently. Push back
 when a simpler approach exists. Ask when the decision is non-routine,
 irreversible, or touches security, data, or shared or production systems.
-For routine decisions, state the assumption and proceed.
+For routine decisions, state the assumption and proceed. When you have a
+question for the user, use the `AskUserQuestion` tool instead of asking in
+plain text.
 
 ## Quality Standards
 


### PR DESCRIPTION
## Summary

Requires use of the `AskUserQuestion` tool for user-facing questions in Claude Code, replacing plain-text question embedding. Documents this behavior pattern in the UX interface guidelines.

## Changes

- `system-configs/CLAUDE.md`: Add directive to General Directive section requiring `AskUserQuestion` tool instead of embedding questions in plain text responses
- `docs/ux/interface-guidelines.md`: Add "Clarification and User Questions" subsection covering when to use the tool, when to proceed with a stated assumption, and a concrete before/after example

## Context

Surfacing questions via `AskUserQuestion` ensures they are clearly visible to the user and enables focused responses rather than burying clarification requests in response text.

## Testing

All 19 tests passing. No test changes required (documentation-only changes to config and guidelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated interface guidelines and system configuration to clarify how clarification requests are handled. The assistant will now use a dedicated tool to request user input for ambiguous situations and high-impact decisions, rather than embedding questions in standard responses. This provides more structured interaction for complex scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->