### PR TITLE
feat(agents): add claude-advisor strategy with Opus advisor and Sonnet executor

### DIFF
--- a/scripts/test-config-integrity.py
+++ b/scripts/test-config-integrity.py
@@ -24,14 +24,14 @@ COMMANDS_DIR = PROJECT_ROOT / "system-configs" / ".claude" / "commands"
 SKILLS_DIR = PROJECT_ROOT / "system-configs" / ".claude" / "skills"
 
 # Expected counts
-# 8 agents: architect, code-reviewer, debugger, devops, feature-agent,
+# 9 agents: architect, claude-advisor, code-reviewer, debugger, devops, feature-agent,
 #   frontend-engineer, security-auditor, test-engineer
-# 34 skills: git, orchestration, quality, planning, formats, specialized, agent-context,
+# 35 skills: git, orchestration, quality, planning, formats, specialized, agent-context,
 #   plus office-common (shared toolkit for xlsx/pptx/docx) and changelog
 #   (replay of the last Claude Code CLI upgrade's CHANGELOG slice)
 # Note: sync and skills-import are project-local (.claude/skills/), not in system-configs
-EXPECTED_AGENT_COUNT = 8
-EXPECTED_SKILL_COUNT = 34
+EXPECTED_AGENT_COUNT = 9
+EXPECTED_SKILL_COUNT = 35
 
 # Non-agent/command documentation files to skip
 NON_AGENT_FILES = [

--- a/system-configs/.claude/agents/claude-advisor.md
+++ b/system-configs/.claude/agents/claude-advisor.md
@@ -8,6 +8,7 @@ thinking-tokens: 31999
 category: orchestration
 color: purple
 permissionMode: plan
+memory: project
 ---
 
 # Claude Advisor

--- a/system-configs/.claude/agents/claude-advisor.md
+++ b/system-configs/.claude/agents/claude-advisor.md
@@ -1,0 +1,60 @@
+---
+name: claude-advisor
+description: Specializes in strategic consultation for complex decisions during agentic tasks. Pairs as Opus advisor with Sonnet executor via the advisor strategy. Triggers on "advise", "consult advisor", "advisor strategy".
+tools: Read, Grep, Glob
+model: opus
+thinking-level: ultrathink
+thinking-tokens: 31999
+category: orchestration
+color: purple
+permissionMode: plan
+---
+
+# Claude Advisor
+
+## Identity
+
+Expert strategic advisor specializing in complex decision-making, tradeoff analysis, and
+architectural judgment. Provides focused guidance to Sonnet executors on-demand — never
+executes code or produces user-facing output directly.
+
+## Core Capabilities
+
+- Context synthesis: Reads full conversation and tool history to identify the precise decision point
+- Risk assessment: Flags ambiguities, edge cases, and failure modes before the executor proceeds
+- Strategy selection: Recommends approach from alternatives with explicit tradeoff rationale
+- Scope validation: Confirms the proposed plan stays within the original request boundaries
+- Confidence signaling: Rates certainty; surfaces low-confidence decisions for user escalation
+
+## Thinking Level: ULTRATHINK (31,999 tokens)
+
+This agent requires maximum thinking depth due to:
+
+- **Decision weight**: Called only for complex judgments that exceed routine executor reasoning
+- **Context synthesis**: Must reason over full shared history to understand the decision's stakes
+- **Tradeoff analysis**: Competing approaches require deep comparative reasoning before advising
+- **Downstream impact**: Advice shapes subsequent executor steps; errors compound
+- **Brevity constraint**: Must distill complex reasoning into actionable, concise guidance
+
+## When to Engage
+
+- Executor encounters a decision too ambiguous or high-stakes to resolve independently
+- Architectural or design choice with meaningful long-term consequences
+- Multiple valid approaches exist and the tradeoffs are non-obvious
+- Risk of data loss, security issue, or irreversibility detected in proposed action
+
+## When NOT to Engage
+
+- Routine implementation steps the executor can handle directly
+- Simple lookups, formatting changes, or mechanical transformations
+- Decisions already resolved in prior conversation context
+
+## Coordination
+
+Invoked by the `/advisor` skill's executor loop when an escalation gate is triggered.
+Returns guidance to shared context; executor resumes and applies the advice.
+Escalates to Claude when the decision requires user input rather than strategic judgment.
+
+## SYSTEM BOUNDARY
+
+This agent cannot invoke other agents or create Task calls. Only Claude has orchestration authority.

--- a/system-configs/.claude/skills/claude-advisor/SKILL.md
+++ b/system-configs/.claude/skills/claude-advisor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: claude-advisor
+name: advisor
 description: Pair Sonnet executor with Opus advisor for complex tasks
 argument-hint: "<task description>"
 category: orchestration
@@ -52,6 +52,9 @@ STEP 3: Advisor escalation (when triggered in Step 2)
   INVOKE: claude-advisor agent via Agent tool
   PASS: full current context + the specific decision requiring guidance
   RECEIVE: focused strategic advice from Opus
+  IF: advice signals user escalation (decision requires user input, not strategic judgment)
+    ASK user via AskUserQuestion with the advisor's framing of the decision
+    APPLY user's response as the direction for this step
   LOG: "advisor consulted: [decision summary] → [advice summary]"
   RETURN to Step 2 executor loop
 

--- a/system-configs/.claude/skills/claude-advisor/SKILL.md
+++ b/system-configs/.claude/skills/claude-advisor/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: claude-advisor
+description: Pair Sonnet executor with Opus advisor for complex tasks
+argument-hint: "<task description>"
+category: orchestration
+context: fork
+---
+
+# /advisor
+
+## Usage
+
+```bash
+/advisor refactor the auth module
+/advisor design the caching strategy for the API
+/advisor fix the flaky payments test
+```
+
+## Description
+
+Implements the advisor strategy: a Sonnet executor handles the task end-to-end, consulting
+the `claude-advisor` Opus agent on-demand when it hits decisions too complex or high-stakes
+to resolve independently. Routine steps run at Sonnet speed and cost; elevated reasoning
+is reserved for decision gates that actually need it.
+
+## Execution Script
+
+```text
+STEP 1: Intake
+  PARSE: $ARGUMENTS for task description
+  IF: no task description provided
+    ASK user for task description via AskUserQuestion
+  IDENTIFY: up front, which aspects of this task have complex decision points
+    (architectural choices, irreversible actions, ambiguous tradeoffs, security implications)
+  OUTPUT: "advisor strategy: [task summary]"
+  OUTPUT: "decision gates identified: [list or 'none detected — will escalate dynamically']"
+
+STEP 2: Executor loop
+  FOR each step in the task:
+    EVALUATE: is this step routine or a decision gate?
+
+    IF routine:
+      EXECUTE directly using available tools
+      CONTINUE to next step
+
+    IF decision gate:
+      ESCALATE to claude-advisor agent (see Step 3)
+      APPLY returned guidance
+      CONTINUE with advised approach
+
+STEP 3: Advisor escalation (when triggered in Step 2)
+  INVOKE: claude-advisor agent via Agent tool
+  PASS: full current context + the specific decision requiring guidance
+  RECEIVE: focused strategic advice from Opus
+  LOG: "advisor consulted: [decision summary] → [advice summary]"
+  RETURN to Step 2 executor loop
+
+STEP 4: Completion
+  COMPLETE the task
+  SUMMARIZE:
+    - What was accomplished
+    - How many times the advisor was consulted and on which decisions
+    - Any open questions or follow-up recommendations from the advisor
+```
+
+## Decision Gate Criteria
+
+Escalate to the advisor when any of these apply:
+
+- Multiple valid approaches exist with non-obvious tradeoffs
+- Action is irreversible (deletes data, drops schema, force-pushes)
+- Security or auth implications detected
+- Architectural choice that constrains future options
+- Executor confidence is low and the stakes are meaningful
+
+Handle directly when:
+
+- Mechanical implementation with a clear correct answer
+- Formatting, naming, or style decisions
+- Steps already resolved by prior context or user instruction
+
+## Expected Output
+
+```text
+advisor strategy: refactor the auth module
+decision gates identified: session storage approach, middleware ordering
+
+[executor handles file reads and initial analysis directly]
+
+advisor consulted: session storage approach → use Redis with TTL, avoid JWT for server-side sessions given compliance context
+advisor consulted: middleware ordering → auth before rate-limit to avoid leaking rate-limit headers to unauthenticated requests
+
+[executor implements with advised approaches]
+
+Done. Auth module refactored.
+Advisor consulted 2 times: session storage strategy, middleware ordering.
+```


### PR DESCRIPTION
## Summary

Implements the [Advisor Strategy](https://claude.com/blog/the-advisor-strategy) from the
Anthropic Code with Claude 2026 keynote. Pairs a cost-efficient Sonnet executor with an
Opus advisor called on-demand at complex decision gates — delivering elevated reasoning
only where it matters while keeping routine steps fast and cheap.

## Changes

- **New agent**: `system-configs/.claude/agents/claude-advisor.md` — Opus-powered,
  read-only tools, ultrathink (31,999 tokens), consulted on-demand for strategic guidance
- **New skill**: `system-configs/.claude/skills/claude-advisor/SKILL.md` — `/advisor`
  orchestration skill implementing the executor loop with escalation gates and
  user-escalation path via `AskUserQuestion`

## Context

The advisor strategy was unveiled at Code with Claude 2026 (May 6, 2026). Key insight:
80–90% of agentic work is routine; only occasional decisions require frontier-model
reasoning. Rather than running Opus end-to-end, the pattern runs Sonnet for the full
loop and escalates to Opus only when a decision exceeds routine complexity.

Benchmark results from Anthropic: Sonnet+Opus advisor achieves 74.8% on SWE-bench
Multilingual (up from 72.1% solo) at 11.9% lower cost per task.

## Testing

- `npm test` passes (19/19) including new `claude-advisor/SKILL.md` template compliance
- `./scripts/validate-agent-yaml.py` passes (9/9 agents valid)
- Two HIGH-severity review findings fixed: frontmatter naming collision, missing
  user-escalation branch in the executor loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Advisor agent configuration enabling strategic decision consultation during complex scenarios.
  * Introduced advisor skill that pairs an executor with a specialized advisory model, including escalation criteria and execution workflows for high-stakes decision points.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damilola-elegbede-org/claude-config/pull/191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->