### PR TITLE
fix(sync): preserve symlinks during backup with cp -RP

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -71,7 +71,7 @@ create_backup() {
     if [ -d "$TARGET_DIR" ]; then
         BACKUP_DIR="$HOME/.claude.backup.$(date +%Y%m%d_%H%M%S)"
         echo "Creating backup at $BACKUP_DIR..."
-        if ! cp -r "$TARGET_DIR" "$BACKUP_DIR"; then
+        if ! cp -RP "$TARGET_DIR" "$BACKUP_DIR"; then
             print_error "Backup failed - aborting sync to prevent data loss"
             return 1
         fi


### PR DESCRIPTION
## Summary
Fix `/sync` backup step failing when `~/.claude` contains broken symlinks (e.g. `debug/latest`).

## Changes
- `scripts/sync.sh`: change `cp -r` to `cp -RP` in `create_backup()`
  - `-R` replaces legacy `-r` for POSIX compliance in `#!/bin/sh` script
  - `-P` preserves symlinks as-is instead of dereferencing them, so broken symlinks no longer abort the backup

## Context
`cp -r` attempts to follow symlinks during copy. When `~/.claude/debug/latest` points to a non-existent debug log file, the copy fails and `/sync` aborts before deploying any configs. The `-P` flag copies the symlink itself, making the backup robust to stale symlinks. Using `-R` over `-r` is also the POSIX-correct form for a `#!/bin/sh` script.

## Testing
Verified fix live: `/sync` ran to completion after the change, creating a backup and deploying 70 files successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)