### PR TITLE
refactor(skills): trim defaults, align with Anthropic skill spec, lean ship-it

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ graph TB
     B --> D[Skill Library]
     B --> E[Configuration Management System]
 
-    C --> F[Parallel Execution via TeamCreate]
+    C --> F[Parallel Execution via Subagent Fan-Out]
     C --> G[Agent Categories]
     C --> H[Security Boundaries]
 

--- a/docs/skills/ORCHESTRATION_SKILL_TEMPLATE.md
+++ b/docs/skills/ORCHESTRATION_SKILL_TEMPLATE.md
@@ -17,7 +17,8 @@ skills/<name>/
 ---
 name: skill-name              # Required: lowercase-hyphenated, matches directory
 description: Brief description # Required: shown in autocomplete
-category: orchestration       # Required: orchestration for complex workflows
+metadata:
+  category: orchestration     # Required: orchestration for complex workflows
 
 # Claude Code Skill Features (all optional)
 context: fork                 # Run in isolated subagent context
@@ -120,9 +121,10 @@ TaskOutput: task_id=<id2>, block=true
 ---
 name: example-orchestrator
 description: Example multi-phase orchestration skill
-category: orchestration
 context: fork
 allowed-tools: Skill, Task, TaskCreate, TaskUpdate, TaskList, TaskOutput
+metadata:
+  category: orchestration
 ---
 ```
 

--- a/docs/skills/SKILL_TEMPLATE.md
+++ b/docs/skills/SKILL_TEMPLATE.md
@@ -19,7 +19,8 @@
 #
 name: skill-name  # lowercase-hyphenated, must match directory name
 description: Brief description under 60 chars
-category: workflow  # language, format, framework, infrastructure, workflow, orchestration
+metadata:
+  category: workflow  # language, format, framework, infrastructure, workflow, orchestration
 ---
 
 # /skill-name Skill

--- a/system-configs/.claude/skills/api-design-patterns/SKILL.md
+++ b/system-configs/.claude/skills/api-design-patterns/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: api-design-patterns
 description: REST and GraphQL API design conventions including versioning, error handling, and response formats.
-category: framework
 user-invocable: false
+metadata:
+  category: framework
 ---
 
 # API Design Patterns Reference

--- a/system-configs/.claude/skills/audit/SKILL.md
+++ b/system-configs/.claude/skills/audit/SKILL.md
@@ -2,7 +2,8 @@
 name: audit
 description: Validate agent and skill ecosystem integrity. Use when checking configuration compliance or ecosystem health.
 argument-hint: "[--scope agents|skills|all] [--fix]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /audit

--- a/system-configs/.claude/skills/branch/SKILL.md
+++ b/system-configs/.claude/skills/branch/SKILL.md
@@ -2,7 +2,8 @@
 name: branch
 description: Create branches with intelligent naming patterns. Use when creating a new git branch.
 argument-hint: "[description]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /branch

--- a/system-configs/.claude/skills/changelog/SKILL.md
+++ b/system-configs/.claude/skills/changelog/SKILL.md
@@ -2,7 +2,8 @@
 name: changelog
 description: Replay the Claude Code CHANGELOG entries from the most recent CLI upgrade. Use when the user wants to revisit "what's new" after the session-start greeting has scrolled away, or asks things like "what changed in the last upgrade", "show me the changelog", "what did I just upgrade into".
 argument-hint: "[--full|<version>]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /changelog

--- a/system-configs/.claude/skills/claude-advisor/SKILL.md
+++ b/system-configs/.claude/skills/claude-advisor/SKILL.md
@@ -2,8 +2,9 @@
 name: advisor
 description: Pair Sonnet executor with Opus advisor for complex tasks
 argument-hint: "<task description>"
-category: orchestration
 context: fork
+metadata:
+  category: orchestration
 ---
 
 # /advisor

--- a/system-configs/.claude/skills/commit/SKILL.md
+++ b/system-configs/.claude/skills/commit/SKILL.md
@@ -2,7 +2,8 @@
 name: commit
 description: Create git commits with intelligent message generation. Use when changes are ready to commit.
 argument-hint: "[--amend]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /commit

--- a/system-configs/.claude/skills/debug/SKILL.md
+++ b/system-configs/.claude/skills/debug/SKILL.md
@@ -2,9 +2,9 @@
 name: debug
 description: Root cause analysis for bugs and performance issues. Use when something is broken, buggy, crashing, slow, or not working.
 argument-hint: "[issue] [--issue|--performance]"
-category: workflow
 context: fork
-agent: debugger
+metadata:
+  category: workflow
 ---
 
 # /debug

--- a/system-configs/.claude/skills/deps/SKILL.md
+++ b/system-configs/.claude/skills/deps/SKILL.md
@@ -2,8 +2,9 @@
 name: deps
 description: Manage dependencies with security scanning and safe updates. Use when auditing or updating dependencies.
 argument-hint: "[audit|update|clean|--quick]"
-category: orchestration
 context: fork
+metadata:
+  category: orchestration
 ---
 
 # /deps

--- a/system-configs/.claude/skills/docs/SKILL.md
+++ b/system-configs/.claude/skills/docs/SKILL.md
@@ -2,9 +2,9 @@
 name: docs
 description: Documentation generation and updates. Use when creating or updating documentation.
 argument-hint: "[scope|--audit|--full|--clean]"
-category: workflow
 context: fork
-agent: tech-writer
+metadata:
+  category: workflow
 ---
 
 # /docs

--- a/system-configs/.claude/skills/feature-lifecycle/SKILL.md
+++ b/system-configs/.claude/skills/feature-lifecycle/SKILL.md
@@ -2,7 +2,8 @@
 name: feature-lifecycle
 description: End-to-end autonomous feature implementation from plan to merged PR. Use when implementing a complete feature, bug fix, or refactor from a spec, GitHub issue, or description.
 argument-hint: "[spec-file|--issue <number>|description]"
-category: orchestration
+metadata:
+  category: orchestration
 ---
 
 # /feature-lifecycle Skill

--- a/system-configs/.claude/skills/fix-ci/SKILL.md
+++ b/system-configs/.claude/skills/fix-ci/SKILL.md
@@ -332,10 +332,12 @@ Common Root Causes:
 - Debugger identity and capabilities embedded in diagnoser spawn prompts (prompt-based specialization)
 - Domain-specific context embedded in fixer spawn prompts
 - Subagents are ephemeral — no cleanup needed after they return
-- When [#24316][tc] lands, replace `subagent_type: "general-purpose"` with
-  custom agent types (the issue tracks teammate inheritance of custom
-  `.claude/agents/` definitions, which would let us use the project's
-  domain-specific agents instead of `general-purpose`)
+- When [#24316][tc] fully ships (i.e. when all teammate inheritance behavior is
+  supported), replace `subagent_type: "general-purpose"` with custom agent
+  types. The issue is still open and partial inheritance already works (system
+  prompt, tools, model are inherited via `subagent_type`); the remaining gap is
+  full inheritance of custom `.claude/agents/` definitions, which would let us
+  use the project's domain-specific agents instead of `general-purpose`.
 - Subagent thinking level: spawned subagents inherit Claude Code's session
   thinking-mode setting. `ultrathink` is a valid keyword and a valid value in
   this repo's `thinking-level` frontmatter (see

--- a/system-configs/.claude/skills/fix-ci/SKILL.md
+++ b/system-configs/.claude/skills/fix-ci/SKILL.md
@@ -238,11 +238,14 @@ TaskUpdate: "Verify CI passes" → completed
 
 ### Step 6: Iterate if Needed
 
-If CI still fails after fix:
+If CI still fails after the fix is pushed:
 
-1. Return to Step 3 (re-diagnose — may be different issues)
-2. Fan out appropriate fixer subagents
-3. Continue until green
+1. **Return to Step 2** — re-fetch CI failure details. The new run's failures
+   may be different (different jobs, different error messages), so don't reuse
+   the previous failure list. Overwrite the previous `.tmp/diagnosis-N.json`
+   files to avoid mixing stale and fresh diagnoses.
+2. Proceed through Steps 3–5 again (diagnose, fix, verify).
+3. Continue until green.
 
 ```text
 TaskList: show final status of all phases
@@ -329,8 +332,15 @@ Common Root Causes:
 - Debugger identity and capabilities embedded in diagnoser spawn prompts (prompt-based specialization)
 - Domain-specific context embedded in fixer spawn prompts
 - Subagents are ephemeral — no cleanup needed after they return
-- When [#24316][tc] lands, replace `subagent_type: "general-purpose"` with custom agent types
-- Thinking level gap: subagents use default thinking, not ultrathink — a real limitation until #24316
+- When [#24316][tc] lands, replace `subagent_type: "general-purpose"` with
+  custom agent types (the issue tracks teammate inheritance of custom
+  `.claude/agents/` definitions, which would let us use the project's
+  domain-specific agents instead of `general-purpose`)
+- Subagent thinking level: spawned subagents inherit Claude Code's session
+  thinking-mode setting. `ultrathink` is a valid keyword and a valid value in
+  this repo's `thinking-level` frontmatter (see
+  `scripts/validate-agent-yaml.py` `THINKING_TOKEN_MAP`); include it in the
+  subagent prompt if a specific diagnosis warrants deeper reasoning.
 - Iterates until GitHub shows all checks green
 
 [tc]: https://github.com/anthropics/claude-code/issues/24316

--- a/system-configs/.claude/skills/fix-ci/SKILL.md
+++ b/system-configs/.claude/skills/fix-ci/SKILL.md
@@ -2,8 +2,9 @@
 name: fix-ci
 description: Diagnose and fix GitHub Actions CI failures. Use when CI pipeline is failing.
 argument-hint: "[run-id|--learn]"
-category: orchestration
 context: fork
+metadata:
+  category: orchestration
 ---
 
 # /fix-ci
@@ -22,16 +23,16 @@ Two-phase CI failure resolution: diagnose with debugger agents, then fix with do
 
 ## Architecture
 
-### Phase 1: Diagnosis (Parallel Debuggers)
+### Phase 1: Diagnosis (Parallel Subagents)
 
-Deploy debugger agents in parallel to investigate each failure. Each debugger returns:
+Fan out debugger subagents in parallel to investigate each failure. Each debugger returns:
 
 - **Root cause**: What actually failed and why
 - **Domain**: Classification for agent routing (see matrix below)
 - **Files**: Specific files that need changes
 - **Fix approach**: Recommended solution
 
-### Phase 2: Fix (Specialized Agents)
+### Phase 2: Fix (Specialized Subagents)
 
 Route fixes to domain experts based on diagnosis:
 
@@ -56,38 +57,24 @@ Route fixes to domain experts based on diagnosis:
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│ 2. TEAM SETUP                                                   │
-│    TeamCreate → fix-ci-{run-id}                                │
-│    Create diagnosis tasks in shared task list                   │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│ 3. DIAGNOSE (Parallel Teammates)                                │
-│    Spawn diagnoser-1..N teammates (one per failure)            │
+│ 2. DIAGNOSE (Parallel Subagents)                                │
+│    Fan out diagnoser-1..N subagents (one per failure)          │
 │    Each returns: { root_cause, domain, files, fix_approach }    │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│ 4. FIX (Parallel Teammates)                                     │
-│    Spawn fixer-{domain} teammates based on classification       │
-│    Each teammate fixes issues in their domain                   │
+│ 3. FIX (Parallel Subagents)                                     │
+│    Fan out fixer-{domain} subagents based on classification     │
+│    Each subagent fixes issues in their domain                   │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│ 5. VERIFY                                                       │
+│ 4. VERIFY                                                       │
 │    Commit fixes, push to remote                                 │
 │    Monitor CI run until complete                                │
 │    If still failing → iterate from step 2                       │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│ 6. CLEANUP (Always runs, even on failure)                       │
-│    SendMessage shutdown_request to all teammates                │
-│    TeamDelete                                                   │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -97,11 +84,9 @@ Route fixes to domain experts based on diagnosis:
 
 ```text
 TaskCreate: "Fetch CI failure details" (no blockers)
-TaskCreate: "Set up diagnosis team" (blockedBy: fetch)
-TaskCreate: "Diagnose failures" (blockedBy: team setup)
+TaskCreate: "Diagnose failures" (blockedBy: fetch)
 TaskCreate: "Fix failures" (blockedBy: diagnose)
 TaskCreate: "Verify CI passes" (blockedBy: fix)
-TaskCreate: "Cleanup team" (blockedBy: verify)
 ```
 
 ### Step 2: Fetch CI Failures
@@ -122,36 +107,21 @@ Extract: job names, failure messages, log URLs
 TaskUpdate: "Fetch CI failure details" → completed
 ```
 
-### Step 3: Create Team and Diagnose (Parallel Teammates)
+### Step 3: Diagnose (Parallel Subagents)
 
 ```text
-TaskUpdate: "Set up diagnosis team" → in_progress
-```
-
-```text
-# Create the team
-TeamCreate:
-  team_name: "fix-ci-{run-id}"
-  description: "CI failure resolution for run {run-id}"
-
-# Create a diagnosis task for each failure
-TaskCreate: "Diagnose: {job-1-name}" (team task)
-TaskCreate: "Diagnose: {job-2-name}" (team task)
-...
-```
-
-```text
-TaskUpdate: "Set up diagnosis team" → completed
 TaskUpdate: "Diagnose failures" → in_progress
 ```
 
-Spawn one diagnoser teammate per failure **in a SINGLE message with multiple Task tool calls**:
+Fan out one diagnoser subagent per failure **in a SINGLE message with multiple
+Task tool calls**. Assign each failure a sequential index (1..N) and pass it to
+the subagent so its output file is `.tmp/diagnosis-<index>.json` — avoids
+unsafe characters from CI job names ending up in filesystem paths.
 
 ```text
 Task tool call 1:
   subagent_type: "general-purpose"
-  name: "diagnoser-1"
-  team_name: "fix-ci-{run-id}"
+  description: "Diagnose <job-1-name>"
   model: "sonnet"
   prompt: |
     You are an expert debugging and performance specialist. Your capabilities:
@@ -168,53 +138,54 @@ Task tool call 1:
 
     ## Your Task
 
-    Investigate CI failure in job '<job-1-name>':
+    Investigate CI failure in job '<job-1-name>' (diagnosis index 1):
     - Error output: <paste relevant log lines>
     - Job URL: <url>
 
     Analyze the failure, read relevant source files, and determine root cause.
 
-    Write your diagnosis to .tmp/diagnosis-{job-1-name}.json:
+    Write your diagnosis to .tmp/diagnosis-1.json:
     {
+      "job_name": "<job-1-name>",
       "root_cause": "Brief description of what failed",
       "domain": "test|security|frontend|backend|data|pipeline|architecture",
       "files": ["list", "of", "files", "to", "fix"],
       "fix_approach": "How to fix this issue"
     }
 
-    Then mark your assigned task as completed.
-
 Task tool call 2:
   subagent_type: "general-purpose"
-  name: "diagnoser-2"
-  team_name: "fix-ci-{run-id}"
+  description: "Diagnose <job-2-name>"
   model: "sonnet"
   prompt: |
     [Same identity preamble as above]
 
     ## Your Task
 
-    Investigate CI failure in job '<job-2-name>':
+    Investigate CI failure in job '<job-2-name>' (diagnosis index 2):
+    Write diagnosis to .tmp/diagnosis-2.json (same schema, include job_name field).
     ...
 ```
 
-Wait for all diagnoser teammates to complete their tasks. Read diagnosis JSON files.
+Wait for all diagnoser subagents to return. Read diagnosis JSON files
+(`.tmp/diagnosis-1.json` … `.tmp/diagnosis-N.json`) — each includes the
+original `job_name` field so log output can reference it.
 
 ```text
 TaskUpdate: "Diagnose failures" → completed
 ```
 
-### Step 4: Classify and Fix (Parallel Teammates)
+### Step 4: Classify and Fix (Parallel Subagents)
 
 ```text
 TaskUpdate: "Fix failures" → in_progress
 ```
 
-Group diagnosis results by domain. Create a fix task for each domain group. Spawn one
-fixer teammate per domain **in a SINGLE message with multiple Task tool calls**:
+Group diagnosis results by domain. Fan out one fixer subagent per domain
+**in a SINGLE message with multiple Task tool calls**:
 
-| Diagnosis Domain | Teammate Name | Prompt Specialization |
-|------------------|---------------|----------------------|
+| Diagnosis Domain | Subagent Description | Prompt Specialization |
+|------------------|----------------------|----------------------|
 | test | fixer-test | Test patterns, mock strategies, assertion fixes |
 | security | fixer-security | Auth fixes, credential handling, vulnerability remediation |
 | frontend | fixer-frontend | React/Vue patterns, CSS fixes, client-side debugging |
@@ -226,8 +197,7 @@ fixer teammate per domain **in a SINGLE message with multiple Task tool calls**:
 ```text
 Task tool call:
   subagent_type: "general-purpose"
-  name: "fixer-{domain}"
-  team_name: "fix-ci-{run-id}"
+  description: "Fix {domain} failures"
   model: "sonnet"
   prompt: |
     You are a {domain} specialist. Fix the following CI failure(s):
@@ -238,10 +208,9 @@ Task tool call:
     - Approach: <from diagnosis>
 
     Implement the fix. Do not make unrelated changes.
-    Then mark your assigned task as completed.
 ```
 
-Wait for all fixer teammates to complete their tasks.
+Wait for all fixer subagents to return.
 
 ```text
 TaskUpdate: "Fix failures" → completed
@@ -267,44 +236,13 @@ gh run watch
 TaskUpdate: "Verify CI passes" → completed
 ```
 
-### Step 6: Cleanup (Always Runs)
-
-**This step runs even if earlier steps fail.** Clean up the team regardless of outcome.
-
-```text
-TaskUpdate: "Cleanup team" → in_progress
-```
-
-```text
-# Shutdown all teammates
-SendMessage:
-  type: "shutdown_request"
-  recipient: "diagnoser-1"
-  content: "Workflow complete, shutting down"
-
-SendMessage:
-  type: "shutdown_request"
-  recipient: "diagnoser-2"
-  content: "Workflow complete, shutting down"
-
-# ... repeat for all active teammates (diagnosers + fixers)
-
-# Delete the team
-TeamDelete
-```
-
-```text
-TaskUpdate: "Cleanup team" → completed
-```
-
-### Step 7: Iterate if Needed
+### Step 6: Iterate if Needed
 
 If CI still fails after fix:
 
-1. Return to Step 3 (create new team with incremented attempt)
-2. Re-diagnose (may be different issues)
-3. Deploy appropriate fix teammates
-4. Continue until green
+1. Return to Step 3 (re-diagnose — may be different issues)
+2. Fan out appropriate fixer subagents
+3. Continue until green
 
 ```text
 TaskList: show final status of all phases
@@ -318,11 +256,8 @@ User: /fix-ci
 🔍 Fetching CI failures from run #987654...
 📊 Found 3 failures: lint, test:unit, build
 
-🏗️ Creating team: fix-ci-987654
-
 🔬 Phase 1: Diagnosis
-   Spawning 3 diagnoser teammates...
-   [tmux panes show diagnoser-1, diagnoser-2, diagnoser-3]
+   Fanning out 3 diagnoser subagents in parallel...
 
    diagnoser-1 (lint):
    └─ Domain: frontend
@@ -340,7 +275,7 @@ User: /fix-ci
    └─ Files: package.json
 
 🔧 Phase 2: Fix
-   Spawning 3 fixer teammates:
+   Fanning out 3 fixer subagents:
    └─ fixer-frontend → src/auth.ts
    └─ fixer-test → tests/api.test.ts
    └─ fixer-pipeline → package.json
@@ -355,7 +290,6 @@ User: /fix-ci
 ⏳ Running... (2 min)
 
 ✅ All CI checks passed!
-🧹 Shutting down team fix-ci-987654...
 🎉 CI fixed in 1 iteration
 ```
 
@@ -389,15 +323,14 @@ Common Root Causes:
 ## Notes
 
 - Two-phase architecture separates diagnosis from fixing
-- Uses TeamCreate for tmux visibility and shared task coordination
-- All teammates spawned with `model: "sonnet"` to match custom agent cost/behavior
-- Fixer teammates for simple domains (docs, lint, config) can use `model: "haiku"` for cost savings
+- Parallelism via subagent fan-out (multiple Task calls in a single message) — no team scaffolding
+- All subagents spawned with `model: "sonnet"` to match custom agent cost/behavior
+- Fixer subagents for simple domains (docs, lint, config) can use `model: "haiku"` for cost savings
 - Debugger identity and capabilities embedded in diagnoser spawn prompts (prompt-based specialization)
 - Domain-specific context embedded in fixer spawn prompts
-- Cleanup step (shutdown + TeamDelete) always runs, even on failure
-- Manual cleanup if needed: `rm -rf ~/.claude/teams/fix-ci-* ~/.claude/tasks/fix-ci-*`
+- Subagents are ephemeral — no cleanup needed after they return
 - When [#24316][tc] lands, replace `subagent_type: "general-purpose"` with custom agent types
-- Thinking level gap: teammates use default thinking, not ultrathink — a real limitation until #24316
+- Thinking level gap: subagents use default thinking, not ultrathink — a real limitation until #24316
 - Iterates until GitHub shows all checks green
 
 [tc]: https://github.com/anthropics/claude-code/issues/24316

--- a/system-configs/.claude/skills/git-conventions/SKILL.md
+++ b/system-configs/.claude/skills/git-conventions/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: git-conventions
 description: Branch naming conventions, conventional commit standards, and PR best practices for consistent git workflows.
-category: workflow
 user-invocable: false
+metadata:
+  category: workflow
 ---
 
 # Git Conventions Reference

--- a/system-configs/.claude/skills/implement/SKILL.md
+++ b/system-configs/.claude/skills/implement/SKILL.md
@@ -2,8 +2,9 @@
 name: implement
 description: Implement features from markdown specs. Use when building features from a specification.
 argument-hint: "[spec-file.md] [--backend|--frontend|--full-stack]"
-category: workflow
 context: fork
+metadata:
+  category: workflow
 ---
 
 # /implement
@@ -19,8 +20,9 @@ context: fork
 ## Description
 
 Reads a markdown specification and implements the described features. Deploys appropriate
-engineers based on the spec requirements. Uses TeamCreate for multi-domain specs (2+ domains),
-or a single Task call for single-domain specs.
+engineers based on the spec requirements. Fans out parallel subagents (one Task call per domain
+in a single message) for multi-domain specs (2+ domains), or a single Task call for single-domain
+specs.
 
 ## Execution Steps
 
@@ -80,36 +82,23 @@ TaskUpdate: "Classify tasks by domain" → completed
 TaskUpdate: "Deploy implementation" → in_progress
 ```
 
-**Decision: Team vs Single Agent**
+**Decision: Fan-Out vs Single Agent**
 
 ```text
 IF: 2+ domains identified
-  → TeamCreate path (parallel teammates)
+  → Subagent fan-out (parallel Task calls in one message)
 ELSE:
-  → Single Task path (no team overhead)
+  → Single Task path
 ```
 
-#### Path A: Multi-Domain (TeamCreate)
+#### Path A: Multi-Domain (Subagent Fan-Out)
 
-```text
-# Create the team
-TeamCreate:
-  team_name: "impl-{current-branch}"
-  description: "Implementation from {spec-file}"
-
-# Create a task for each domain's work
-TaskCreate: "Implement {domain-1} tasks" (team task)
-TaskCreate: "Implement {domain-2} tasks" (team task)
-...
-```
-
-Spawn one teammate per domain **in a SINGLE message with multiple Task tool calls**:
+Fan out one subagent per domain **in a SINGLE message with multiple Task tool calls**:
 
 ```text
 Task tool call:
   subagent_type: "general-purpose"
-  name: "{domain}-engineer"
-  team_name: "impl-{current-branch}"
+  description: "Implement {domain} tasks"
   model: "sonnet"
   prompt: |
     You are a {domain} specialist implementing features from a specification.
@@ -122,8 +111,8 @@ Task tool call:
     {list of files assigned to this domain}
 
     Do NOT modify files outside your ownership list. If you need changes
-    to a file you don't own, document the needed change and mark your task
-    as completed with a note.
+    to a file you don't own, document the needed change and return a note
+    describing what's needed.
 
     ## Dependencies
     {any task dependency information}
@@ -131,16 +120,10 @@ Task tool call:
     ## Acceptance Criteria
     {relevant acceptance criteria from spec}
 
-    Implement each task, then mark your assigned tasks as completed.
+    Implement each task and return a summary of changes made.
 ```
 
-Wait for all teammates to complete their tasks.
-
-```text
-# Cleanup team
-SendMessage shutdown_request to all teammates
-TeamDelete
-```
+Wait for all subagents to return.
 
 #### Path B: Single Domain (Task)
 
@@ -202,17 +185,12 @@ User: /implement feature-spec.md
   - backend (3 tasks): API endpoints, validation, auth middleware
   - frontend (2 tasks): UserProfile component, form integration
 
-🏗️ Creating team: impl-feature-user-profile
-   Spawning 2 teammates...
-   [tmux panes show backend-engineer, frontend-engineer]
-
+Fanning out 2 subagents in parallel...
    backend-engineer owns: src/api/, src/middleware/, src/models/
    frontend-engineer owns: src/components/, src/pages/
 
    ✓ backend-engineer: 3/3 tasks completed
    ✓ frontend-engineer: 2/2 tasks completed
-
-🧹 Shutting down team impl-feature-user-profile...
 
 🧪 Running tests...
 ✅ All tests passing
@@ -251,7 +229,7 @@ User: /implement spec.md --dry-run
   - backend: 3 tasks (API endpoints, validation, auth)
   - frontend: 2 tasks (UserProfile, form integration)
 
-  Deployment: TeamCreate (2 domains → parallel teammates)
+  Deployment: Subagent fan-out (2 domains → parallel Task calls)
   File ownership:
     backend-engineer: src/api/, src/middleware/
     frontend-engineer: src/components/, src/pages/
@@ -279,14 +257,13 @@ Ready to proceed? Run without --dry-run
 
 ## Notes
 
-- Uses TeamCreate for 2+ domains, single Task for 1 domain (avoids team overhead)
-- All teammates spawned with `model: "sonnet"` to match custom agent cost/behavior
+- Parallel subagent fan-out for 2+ domains (multiple Task calls in a single message); single Task for 1 domain
+- All subagents spawned with `model: "sonnet"` to match custom agent cost/behavior
 - Docs-domain tasks use `model: "haiku"` (template-following, structured output)
 - Well-scoped implementation tasks can be delegated to Codex via `/codex` for cost savings
-- File ownership prevents conflicts between teammates working in parallel
+- File ownership prevents conflicts between subagents working in parallel
 - Shared files (types, configs) assigned to exactly one domain
-- Cleanup (shutdown + TeamDelete) always runs after multi-domain deployment
-- Manual cleanup if needed: `rm -rf ~/.claude/teams/impl-* ~/.claude/tasks/impl-*`
+- Subagents are ephemeral — no cleanup needed after they return
 - When [#24316](https://github.com/anthropics/claude-code/issues/24316) lands, replace `subagent_type: "general-purpose"` with custom agent types
 - Respects task dependencies within and across domains
 - Use `--incremental` to resume partial implementations

--- a/system-configs/.claude/skills/merge/SKILL.md
+++ b/system-configs/.claude/skills/merge/SKILL.md
@@ -2,7 +2,8 @@
 name: merge
 description: Merge a branch into current branch with conflict handling. Use when merging branches.
 argument-hint: "[source_branch] [--theirs|--ours|--abort]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /merge

--- a/system-configs/.claude/skills/plan/SKILL.md
+++ b/system-configs/.claude/skills/plan/SKILL.md
@@ -2,9 +2,9 @@
 name: plan
 description: Generate PRD and task files for implementation. Use when planning a feature, project, or task.
 argument-hint: "[task] [--simple|--no-execute|--file]"
-category: workflow
 context: fork
-agent: architect
+metadata:
+  category: workflow
 ---
 
 # /plan

--- a/system-configs/.claude/skills/pr/SKILL.md
+++ b/system-configs/.claude/skills/pr/SKILL.md
@@ -2,7 +2,8 @@
 name: pr
 description: Create pull requests with smart title and description generation. Use when creating a PR.
 argument-hint: "[target_branch] [--draft|--force]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /pr

--- a/system-configs/.claude/skills/prime/SKILL.md
+++ b/system-configs/.claude/skills/prime/SKILL.md
@@ -2,9 +2,9 @@
 name: prime
 description: Build repository understanding and context. Use when onboarding to a codebase or building context.
 argument-hint: "[--lite|--full|component-name]"
-category: workflow
 context: fork
-agent: researcher
+metadata:
+  category: workflow
 ---
 
 # /prime

--- a/system-configs/.claude/skills/prompt/SKILL.md
+++ b/system-configs/.claude/skills/prompt/SKILL.md
@@ -2,7 +2,8 @@
 name: prompt
 description: Optimize prompts using direct execution with SCOPE framework. Use when refining or improving prompts.
 argument-hint: "[text|--file|--f]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /prompt

--- a/system-configs/.claude/skills/push/SKILL.md
+++ b/system-configs/.claude/skills/push/SKILL.md
@@ -2,7 +2,8 @@
 name: push
 description: Push changes to remote repository with validation. Use when pushing committed changes.
 argument-hint: "[--force|--dry-run]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /push

--- a/system-configs/.claude/skills/rebase/SKILL.md
+++ b/system-configs/.claude/skills/rebase/SKILL.md
@@ -2,7 +2,8 @@
 name: rebase
 description: Rebase current branch on latest main or specified branch. Use when updating branch with upstream changes.
 argument-hint: "[target_branch] [--continue|--abort]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /rebase

--- a/system-configs/.claude/skills/resolve-comments/SKILL.md
+++ b/system-configs/.claude/skills/resolve-comments/SKILL.md
@@ -2,7 +2,8 @@
 name: resolve-comments
 description: Resolve review comments from any source. Use when addressing PR review feedback.
 argument-hint: "[pr-number] [--code-rabbit|--local|--auto|--dry-run]"
-category: orchestration
+metadata:
+  category: orchestration
 ---
 
 # /resolve-comments

--- a/system-configs/.claude/skills/review/SKILL.md
+++ b/system-configs/.claude/skills/review/SKILL.md
@@ -2,8 +2,9 @@
 name: review
 description: Comprehensive code review using code-reviewer agent with assertive analysis. Use when reviewing code changes.
 argument-hint: "[--full|--deep]"
-category: orchestration
 context: fork
+metadata:
+  category: orchestration
 ---
 
 # /review
@@ -22,7 +23,7 @@ Comprehensive code review that launches a code-reviewer agent with a thorough,
 assertive review prompt covering security, bugs, performance, best practices,
 and code quality.
 
-With `--deep`, spawns a three-reviewer team via TeamCreate for multi-perspective
+With `--deep`, fans out three subagents in parallel for multi-perspective
 analysis: code quality, security, and accessibility. Each reviewer writes to a
 separate output file; results are merged and deduplicated before triage.
 
@@ -63,171 +64,31 @@ ELSE:
   → Go to Step 3b (Single Reviewer)
 ```
 
-### Step 3a: Deep Review (TeamCreate)
+### Step 3a: Deep Review (Subagent Fan-Out)
 
-Create a review team with three specialized reviewers. All run in parallel.
-Read-only behavior enforced via prompt constraints (do not modify source files).
+Fan out three specialized reviewer subagents in parallel. Read-only behavior
+enforced via prompt constraints (do not modify source files).
 
-```text
-# Create the team
-TeamCreate:
-  team_name: "review-{current-branch}"
-  description: "Deep review of {current-branch}"
-```
-
-Spawn three reviewer teammates **in a SINGLE message with multiple Task tool calls**:
+Spawn all three reviewers **in a SINGLE message with multiple Task tool calls**:
 
 ```text
 Task tool call 1:
   subagent_type: "general-purpose"
-  name: "code-reviewer"
-  team_name: "review-{current-branch}"
+  description: "Code-quality review"
   model: "sonnet"
-  prompt: |
-    You are an elite staff-level code reviewer. Your capabilities:
-
-    **Code Quality:**
-    - Automated linting: ESLint, ruff, golangci-lint, clippy with blocking enforcement
-    - Security analysis: Vulnerability detection, OWASP compliance, injection prevention
-    - Performance review: Algorithm complexity, memory leaks, database query optimization
-    - Quality gates: 80%+ test coverage, cyclomatic complexity <10, DRY enforcement
-    - Multi-language: JavaScript/TypeScript, Python, Go, Rust, full-stack patterns
-    - Architecture review: Design patterns, SOLID principles, maintainability
-
-    ## Git Conventions Reference
-    {embed full content of git-conventions skill}
-
-    ## Your Task
-
-    Review the following files for bugs, performance, best practices, and code quality.
-    IMPORTANT: Do NOT modify any source files. Only read source files and write your
-    findings to the output file below.
-
-    Files to review:
-    {file_list from Step 2}
-
-    Write your findings to .tmp/review-code.json using this schema:
-    {
-      "schema_version": "1.0",
-      "branch": "{current_branch}",
-      "created_at": "{ISO timestamp}",
-      "source": "code-reviewer",
-      "summary": "Brief overall assessment",
-      "walkthrough": [{"file": "path", "description": "what changed"}],
-      "issues": [
-        {
-          "id": {sequential number},
-          "file": "path/to/file",
-          "line": {line number or null},
-          "severity": "LOW|MEDIUM|HIGH|CRITICAL",
-          "type": "bugs|performance|best-practices|code-quality",
-          "description": "Issue description",
-          "suggestion": "Concrete fix"
-        }
-      ]
-    }
-
-    Use the assertive review profile: no hedging, imperative language,
-    focus exclusively on problems.
+  prompt: contents of `references/code-review-prompt.md`, with `{file_list}` from Step 2, `{current_branch}`, and `{ISO timestamp}` substituted
 
 Task tool call 2:
   subagent_type: "general-purpose"
-  name: "security-reviewer"
-  team_name: "review-{current-branch}"
+  description: "Security review"
   model: "sonnet"
-  prompt: |
-    You are a security specialist conducting a focused security review.
-    IMPORTANT: Do NOT modify any source files. Only read source files and write your
-    findings to the output file below.
-
-    ## Security Checklist Reference
-    {embed full content of security-checklist skill}
-
-    ## Your Task
-
-    Review the following files exclusively for security issues:
-    - Injection vulnerabilities (SQL, command, XSS, SSRF)
-    - Authentication and authorization flaws
-    - Data exposure (secrets, PII, sensitive data in logs)
-    - Insecure deserialization, path traversal
-    - Missing input validation at trust boundaries
-    - Hardcoded credentials or API keys
-    - OWASP Top 10 compliance
-
-    Files to review:
-    {file_list from Step 2}
-
-    Write your findings to .tmp/review-security.json using this schema:
-    {
-      "schema_version": "1.0",
-      "branch": "{current_branch}",
-      "created_at": "{ISO timestamp}",
-      "source": "security-reviewer",
-      "summary": "Security assessment",
-      "walkthrough": [{"file": "path", "description": "security-relevant changes"}],
-      "issues": [
-        {
-          "id": {sequential number},
-          "file": "path/to/file",
-          "line": {line number or null},
-          "severity": "LOW|MEDIUM|HIGH|CRITICAL",
-          "type": "security",
-          "description": "Issue description",
-          "suggestion": "Concrete fix"
-        }
-      ]
-    }
-
-    Severity escalation: any issue in auth/payment/PII code → escalate one level.
+  prompt: contents of `references/security-review-prompt.md`, with `{file_list}` from Step 2, `{current_branch}`, and `{ISO timestamp}` substituted
 
 Task tool call 3:
   subagent_type: "general-purpose"
-  name: "a11y-reviewer"
-  team_name: "review-{current-branch}"
+  description: "Accessibility review"
   model: "haiku"
-  prompt: |
-    You are an accessibility specialist conducting a focused accessibility review.
-    IMPORTANT: Do NOT modify any source files. Only read source files and write your
-    findings to the output file below.
-
-    ## Your Task
-
-    Review the following files exclusively for accessibility issues:
-    - Missing or incorrect ARIA attributes
-    - Keyboard navigation gaps
-    - Color contrast violations (WCAG AA minimum)
-    - Missing alt text on images
-    - Form labels and error announcements
-    - Focus management issues
-    - Screen reader compatibility
-    - Semantic HTML usage
-
-    Files to review:
-    {file_list from Step 2}
-
-    Write your findings to .tmp/review-accessibility.json using this schema:
-    {
-      "schema_version": "1.0",
-      "branch": "{current_branch}",
-      "created_at": "{ISO timestamp}",
-      "source": "a11y-reviewer",
-      "summary": "Accessibility assessment",
-      "walkthrough": [{"file": "path", "description": "a11y-relevant changes"}],
-      "issues": [
-        {
-          "id": {sequential number},
-          "file": "path/to/file",
-          "line": {line number or null},
-          "severity": "LOW|MEDIUM|HIGH|CRITICAL",
-          "type": "accessibility",
-          "description": "Issue description",
-          "suggestion": "Concrete fix"
-        }
-      ]
-    }
-
-    If no frontend/UI files are in scope, write empty issues array with
-    summary: "No UI files in scope for accessibility review."
+  prompt: contents of `references/a11y-review-prompt.md`, with `{file_list}` from Step 2, `{current_branch}`, and `{ISO timestamp}` substituted
 ```
 
 Wait for all reviewers to complete. Then merge results:
@@ -251,167 +112,20 @@ MERGE: Combine all issues into .tmp/review-local.json
   - Re-number issue IDs sequentially
   - Combine walkthroughs (deduplicate by file)
   - Set source: "deep-review"
-
-# Cleanup team
-SendMessage shutdown_request to code-reviewer, security-reviewer, a11y-reviewer
-TeamDelete
 ```
 
 Go to Step 4.
 
 ### Step 3b: Single Reviewer (Default)
 
-Launch a single code-reviewer agent with the comprehensive review prompt below.
+Launch a single code-reviewer agent with the comprehensive review prompt
+in `references/single-review-prompt.md`.
 
 ```yaml
 Task tool:
   subagent_type: "code-reviewer"
   description: "Run comprehensive code review"
-  prompt: |
-    You are an elite code reviewer conducting a comprehensive, assertive analysis.
-    Review the following files and output results to .tmp/review-local.json
-
-    Create .tmp/ directory if needed: mkdir -p .tmp
-
-    Files to review:
-    {file_list from Step 2}
-
-    ===== REVIEW INSTRUCTIONS =====
-
-    ## Output Structure
-
-    Your review MUST follow this three-part structure:
-
-    ### Part 1: Summary
-    A concise overview of changes, their purpose, and overall assessment.
-
-    ### Part 2: Walkthrough
-    For each changed file, provide:
-    - File path
-    - Brief description of what changed and why
-    - Any architectural implications
-
-    ### Part 3: Inline Comments
-    Specific, actionable findings tied to exact file paths and line numbers.
-
-    ## Analysis Domains
-
-    Evaluate ALL five domains for every file:
-
-    **1. Security**
-    - Injection vulnerabilities (SQL, command, XSS, SSRF)
-    - Authentication and authorization flaws
-    - Data exposure (secrets, PII, sensitive data in logs)
-    - Insecure deserialization, path traversal
-    - Missing input validation at trust boundaries
-    - Hardcoded credentials or API keys
-
-    **2. Bugs & Correctness**
-    - Null/undefined reference errors
-    - Off-by-one errors, boundary conditions
-    - Race conditions, concurrency issues
-    - Incorrect error handling (swallowed exceptions, wrong error types)
-    - Logic errors in conditionals and loops
-    - Type mismatches and implicit conversions
-    - Resource leaks (unclosed handles, missing cleanup)
-
-    **3. Performance**
-    - N+1 query patterns
-    - Unnecessary re-renders or recomputations
-    - Memory leaks (event listeners, closures, circular references)
-    - Algorithm complexity (O(n^2) where O(n) is possible)
-    - Unbounded data structures (missing pagination, limits)
-    - Blocking operations on hot paths
-    - Missing caching opportunities
-
-    **4. Best Practices**
-    - DRY violations (duplicated logic)
-    - SOLID principle violations
-    - Missing or inadequate error handling
-    - Poor naming (unclear, misleading, inconsistent)
-    - Magic numbers and hardcoded values
-    - Missing input validation
-    - Inconsistent patterns within the codebase
-
-    **5. Code Quality**
-    - Cyclomatic complexity > 10
-    - Functions > 50 lines
-    - Deep nesting (> 3 levels)
-    - Missing edge case handling
-    - Unclear control flow
-    - Dead code or unreachable branches
-    - Inconsistent formatting or style
-
-    ## Language-Specific Checks
-
-    **Python:**
-    - Mutable default arguments
-    - Missing `__init__.py` for packages
-    - Bare `except:` clauses
-    - f-string injection in logging
-    - Missing type hints on public APIs
-    - Unsafe `eval()`/`exec()` usage
-
-    **TypeScript/JavaScript:**
-    - `any` type usage (should be narrowed)
-    - Missing `await` on async calls
-    - Prototype pollution vectors
-    - Unsafe `innerHTML` or `dangerouslySetInnerHTML`
-    - Missing error boundaries in React
-    - Unhandled promise rejections
-
-    ## Review Profile: Assertive
-
-    - DO NOT hedge or soften findings. State issues directly.
-    - Use imperative language: "Fix this", "Remove this", "This must be changed"
-    - Every finding must include a concrete fix suggestion
-    - Do not praise code. Focus exclusively on problems.
-    - If code is acceptable, say so briefly and move on.
-    - Treat "it works" as insufficient — code must be correct, secure, and maintainable.
-
-    ## Severity Rules
-
-    - **CRITICAL**: Security vulnerabilities, data loss risks, crashes in production
-    - **HIGH**: Bugs that will manifest in normal usage, significant performance issues
-    - **MEDIUM**: Best practice violations, maintainability concerns, minor performance issues
-    - **LOW**: Style issues, minor improvements, nice-to-haves
-
-    Severity escalation:
-    - Any issue in auth/payment/PII handling code: escalate one level
-    - Any issue that affects multiple files or is systemic: escalate one level
-    - Any issue with a simple, obvious fix: do not de-escalate (easy to fix != unimportant)
-
-    ## Output Format
-
-    Write results to .tmp/review-local.json with this schema:
-    {
-      "schema_version": "1.0",
-      "branch": "{current_branch}",
-      "created_at": "{ISO timestamp}",
-      "source": "code-reviewer",
-      "summary": "Brief overall assessment",
-      "walkthrough": [
-        {
-          "file": "path/to/file",
-          "description": "What changed and why"
-        }
-      ],
-      "issues": [
-        {
-          "id": {sequential number},
-          "file": "path/to/file",
-          "line": {line number or null},
-          "severity": "LOW|MEDIUM|HIGH|CRITICAL",
-          "type": "security|bugs|performance|best-practices|code-quality",
-          "description": "Issue description - be specific and direct",
-          "suggestion": "Concrete fix with code example when applicable"
-        }
-      ]
-    }
-
-    Report: "Code reviewer found {count} issues"
-
-    If no issues found, write empty issues array with summary.
+  prompt: contents of `references/single-review-prompt.md`, with `{file_list}` from Step 2, `{current_branch}`, and `{ISO timestamp}` substituted
 ```
 
 ### Step 4: Report Results
@@ -500,16 +214,13 @@ User: /review --deep
 Starting code review analysis...
 Mode: Branch delta review (5 files)
 
-🏗️ Creating team: review-feature-auth
-   Spawning 3 reviewers...
-   [tmux panes show code-reviewer, security-reviewer, a11y-reviewer]
+Spawning 3 reviewer subagents in parallel...
 
    ✓ code-reviewer: 4 issues found
    ✓ security-reviewer: 2 issues found
    ✓ a11y-reviewer: 1 issue found
 
 Merging and deduplicating results...
-🧹 Shutting down team review-feature-auth...
 
 Deep Review Complete
 
@@ -535,11 +246,10 @@ Launching interactive triage...
 - Results stored in `.tmp/` for `/resolve-comments` consumption
 - No auto-fix — all changes require user approval via triage
 - `--full` mode may take longer depending on codebase size
-- `--deep` spawns three reviewers via TeamCreate for multi-perspective analysis
+- `--deep` fans out three subagents in parallel for multi-perspective analysis
 - Code and security reviewers use `model: "sonnet"`; a11y-reviewer uses `model: "haiku"` (checklist-driven, structured output)
 - Code-reviewer prompt embeds `git-conventions` skill; security-reviewer embeds `security-checklist`
-- Cleanup (shutdown + TeamDelete) always runs after `--deep` review
-- Manual cleanup if needed: `rm -rf ~/.claude/teams/review-* ~/.claude/tasks/review-*`
+- Subagents are ephemeral — no cleanup needed after they return
 - When [#24316][tc] lands, replace `subagent_type: "general-purpose"` with custom agent types
 
 [tc]: https://github.com/anthropics/claude-code/issues/24316

--- a/system-configs/.claude/skills/review/references/a11y-review-prompt.md
+++ b/system-configs/.claude/skills/review/references/a11y-review-prompt.md
@@ -1,0 +1,51 @@
+Reviewer prompt for the accessibility subagent in `/review --deep`.
+Substitute `{file_list}`, `{current_branch}`, and `{ISO timestamp}` before passing.
+
+---
+
+You are an accessibility specialist conducting a focused accessibility review.
+IMPORTANT: Do NOT modify any source files. Only read source files and write your
+findings to the output file below.
+
+## Your Task
+
+Review the following files exclusively for accessibility issues:
+
+- Missing or incorrect ARIA attributes
+- Keyboard navigation gaps
+- Color contrast violations (WCAG AA minimum)
+- Missing alt text on images
+- Form labels and error announcements
+- Focus management issues
+- Screen reader compatibility
+- Semantic HTML usage
+
+Files to review:
+{file_list}
+
+Write your findings to .tmp/review-accessibility.json using this schema:
+
+```json
+{
+  "schema_version": "1.0",
+  "branch": "{current_branch}",
+  "created_at": "{ISO timestamp}",
+  "source": "a11y-reviewer",
+  "summary": "Accessibility assessment",
+  "walkthrough": [{"file": "path", "description": "a11y-relevant changes"}],
+  "issues": [
+    {
+      "id": "<sequential number>",
+      "file": "path/to/file",
+      "line": "<line number or null>",
+      "severity": "LOW|MEDIUM|HIGH|CRITICAL",
+      "type": "accessibility",
+      "description": "Issue description",
+      "suggestion": "Concrete fix"
+    }
+  ]
+}
+```
+
+If no frontend/UI files are in scope, write empty issues array with
+summary: "No UI files in scope for accessibility review."

--- a/system-configs/.claude/skills/review/references/code-review-prompt.md
+++ b/system-configs/.claude/skills/review/references/code-review-prompt.md
@@ -1,0 +1,57 @@
+Reviewer prompt for the code-quality subagent in `/review --deep`.
+Substitute `{file_list}`, `{current_branch}`, and `{ISO timestamp}` before passing.
+
+---
+
+You are an elite staff-level code reviewer. Your capabilities:
+
+**Code Quality:**
+
+- Automated linting: ESLint, ruff, golangci-lint, clippy with blocking enforcement
+- Security analysis: Vulnerability detection, OWASP compliance, injection prevention
+- Performance review: Algorithm complexity, memory leaks, database query optimization
+- Quality gates: 80%+ test coverage, cyclomatic complexity <10, DRY enforcement
+- Multi-language: JavaScript/TypeScript, Python, Go, Rust, full-stack patterns
+- Architecture review: Design patterns, SOLID principles, maintainability
+
+## Git Conventions Reference
+
+Apply branch naming, conventional commit, and PR conventions from the
+`git-conventions` skill. Consult `~/.claude/skills/git-conventions/SKILL.md`
+if you need the full reference.
+
+## Your Task
+
+Review the following files for bugs, performance, best practices, and code quality.
+IMPORTANT: Do NOT modify any source files. Only read source files and write your
+findings to the output file below.
+
+Files to review:
+{file_list}
+
+Write your findings to .tmp/review-code.json using this schema:
+
+```json
+{
+  "schema_version": "1.0",
+  "branch": "{current_branch}",
+  "created_at": "{ISO timestamp}",
+  "source": "code-reviewer",
+  "summary": "Brief overall assessment",
+  "walkthrough": [{"file": "path", "description": "what changed"}],
+  "issues": [
+    {
+      "id": "<sequential number>",
+      "file": "path/to/file",
+      "line": "<line number or null>",
+      "severity": "LOW|MEDIUM|HIGH|CRITICAL",
+      "type": "bugs|performance|best-practices|code-quality",
+      "description": "Issue description",
+      "suggestion": "Concrete fix"
+    }
+  ]
+}
+```
+
+Use the assertive review profile: no hedging, imperative language,
+focus exclusively on problems.

--- a/system-configs/.claude/skills/review/references/security-review-prompt.md
+++ b/system-configs/.claude/skills/review/references/security-review-prompt.md
@@ -1,0 +1,55 @@
+Reviewer prompt for the security subagent in `/review --deep`.
+Substitute `{file_list}`, `{current_branch}`, and `{ISO timestamp}` before passing.
+
+---
+
+You are a security specialist conducting a focused security review.
+IMPORTANT: Do NOT modify any source files. Only read source files and write your
+findings to the output file below.
+
+## Security Checklist Reference
+
+Reference the `security-checklist` skill for OWASP Top 10 patterns and
+common vulnerability classes. Consult `~/.claude/skills/security-checklist/SKILL.md`
+if you need the full checklist.
+
+## Your Task
+
+Review the following files exclusively for security issues:
+
+- Injection vulnerabilities (SQL, command, XSS, SSRF)
+- Authentication and authorization flaws
+- Data exposure (secrets, PII, sensitive data in logs)
+- Insecure deserialization, path traversal
+- Missing input validation at trust boundaries
+- Hardcoded credentials or API keys
+- OWASP Top 10 compliance
+
+Files to review:
+{file_list}
+
+Write your findings to .tmp/review-security.json using this schema:
+
+```json
+{
+  "schema_version": "1.0",
+  "branch": "{current_branch}",
+  "created_at": "{ISO timestamp}",
+  "source": "security-reviewer",
+  "summary": "Security assessment",
+  "walkthrough": [{"file": "path", "description": "security-relevant changes"}],
+  "issues": [
+    {
+      "id": "<sequential number>",
+      "file": "path/to/file",
+      "line": "<line number or null>",
+      "severity": "LOW|MEDIUM|HIGH|CRITICAL",
+      "type": "security",
+      "description": "Issue description",
+      "suggestion": "Concrete fix"
+    }
+  ]
+}
+```
+
+Severity escalation: any issue in auth/payment/PII code → escalate one level.

--- a/system-configs/.claude/skills/review/references/single-review-prompt.md
+++ b/system-configs/.claude/skills/review/references/single-review-prompt.md
@@ -1,0 +1,164 @@
+Reviewer prompt for the single-reviewer agent in default `/review` mode.
+Substitute `{file_list}`, `{current_branch}`, and `{ISO timestamp}` before passing.
+
+---
+
+You are an elite code reviewer conducting a comprehensive, assertive analysis.
+Review the following files and output results to .tmp/review-local.json
+
+Create .tmp/ directory if needed: mkdir -p .tmp
+
+Files to review:
+{file_list}
+
+===== REVIEW INSTRUCTIONS =====
+
+## Output Structure
+
+Your review MUST follow this three-part structure:
+
+### Part 1: Summary
+
+A concise overview of changes, their purpose, and overall assessment.
+
+### Part 2: Walkthrough
+
+For each changed file, provide:
+
+- File path
+- Brief description of what changed and why
+- Any architectural implications
+
+### Part 3: Inline Comments
+
+Specific, actionable findings tied to exact file paths and line numbers.
+
+## Analysis Domains
+
+Evaluate ALL five domains for every file:
+
+**1. Security**
+
+- Injection vulnerabilities (SQL, command, XSS, SSRF)
+- Authentication and authorization flaws
+- Data exposure (secrets, PII, sensitive data in logs)
+- Insecure deserialization, path traversal
+- Missing input validation at trust boundaries
+- Hardcoded credentials or API keys
+
+**2. Bugs & Correctness**
+
+- Null/undefined reference errors
+- Off-by-one errors, boundary conditions
+- Race conditions, concurrency issues
+- Incorrect error handling (swallowed exceptions, wrong error types)
+- Logic errors in conditionals and loops
+- Type mismatches and implicit conversions
+- Resource leaks (unclosed handles, missing cleanup)
+
+**3. Performance**
+
+- N+1 query patterns
+- Unnecessary re-renders or recomputations
+- Memory leaks (event listeners, closures, circular references)
+- Algorithm complexity (O(n^2) where O(n) is possible)
+- Unbounded data structures (missing pagination, limits)
+- Blocking operations on hot paths
+- Missing caching opportunities
+
+**4. Best Practices**
+
+- DRY violations (duplicated logic)
+- SOLID principle violations
+- Missing or inadequate error handling
+- Poor naming (unclear, misleading, inconsistent)
+- Magic numbers and hardcoded values
+- Missing input validation
+- Inconsistent patterns within the codebase
+
+**5. Code Quality**
+
+- Cyclomatic complexity > 10
+- Functions > 50 lines
+- Deep nesting (> 3 levels)
+- Missing edge case handling
+- Unclear control flow
+- Dead code or unreachable branches
+- Inconsistent formatting or style
+
+## Language-Specific Checks
+
+**Python:**
+
+- Mutable default arguments
+- Missing `__init__.py` for packages
+- Bare `except:` clauses
+- f-string injection in logging
+- Missing type hints on public APIs
+- Unsafe `eval()`/`exec()` usage
+
+**TypeScript/JavaScript:**
+
+- `any` type usage (should be narrowed)
+- Missing `await` on async calls
+- Prototype pollution vectors
+- Unsafe `innerHTML` or `dangerouslySetInnerHTML`
+- Missing error boundaries in React
+- Unhandled promise rejections
+
+## Review Profile: Assertive
+
+- DO NOT hedge or soften findings. State issues directly.
+- Use imperative language: "Fix this", "Remove this", "This must be changed"
+- Every finding must include a concrete fix suggestion
+- Do not praise code. Focus exclusively on problems.
+- If code is acceptable, say so briefly and move on.
+- Treat "it works" as insufficient — code must be correct, secure, and maintainable.
+
+## Severity Rules
+
+- **CRITICAL**: Security vulnerabilities, data loss risks, crashes in production
+- **HIGH**: Bugs that will manifest in normal usage, significant performance issues
+- **MEDIUM**: Best practice violations, maintainability concerns, minor performance issues
+- **LOW**: Style issues, minor improvements, nice-to-haves
+
+Severity escalation:
+
+- Any issue in auth/payment/PII handling code: escalate one level
+- Any issue that affects multiple files or is systemic: escalate one level
+- Any issue with a simple, obvious fix: do not de-escalate (easy to fix != unimportant)
+
+## Output Format
+
+Write results to .tmp/review-local.json with this schema:
+
+```json
+{
+  "schema_version": "1.0",
+  "branch": "{current_branch}",
+  "created_at": "{ISO timestamp}",
+  "source": "code-reviewer",
+  "summary": "Brief overall assessment",
+  "walkthrough": [
+    {
+      "file": "path/to/file",
+      "description": "What changed and why"
+    }
+  ],
+  "issues": [
+    {
+      "id": "<sequential number>",
+      "file": "path/to/file",
+      "line": "<line number or null>",
+      "severity": "LOW|MEDIUM|HIGH|CRITICAL",
+      "type": "security|bugs|performance|best-practices|code-quality",
+      "description": "Issue description - be specific and direct",
+      "suggestion": "Concrete fix with code example when applicable"
+    }
+  ]
+}
+```
+
+Report: "Code reviewer found {count} issues"
+
+If no issues found, write empty issues array with summary.

--- a/system-configs/.claude/skills/security-checklist/SKILL.md
+++ b/system-configs/.claude/skills/security-checklist/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: security-checklist
 description: OWASP Top 10 quick reference and common vulnerability patterns for security-focused code review and auditing.
-category: workflow
 user-invocable: false
+metadata:
+  category: workflow
 ---
 
 # Security Checklist Reference

--- a/system-configs/.claude/skills/ship-it/SKILL.md
+++ b/system-configs/.claude/skills/ship-it/SKILL.md
@@ -58,9 +58,14 @@ Run enabled steps in this fixed order; halt immediately on failure:
 4. **Commit + push + PR** (after any of -d/-t/-r have run): pick the right path
    based on which of `-c`, `-p`, `-pr` are set (in the no-flag default, all
    three are set, so this step runs `commit-commands:commit-push-pr`):
-   - All three of `-c -p -pr` set (including the no-flag default): one tool
-     call to `commit-commands:commit-push-pr`. No TaskCreate ceremony, no
-     orchestration.
+   - All three of `-c -p -pr` set (including the no-flag default):
+     - **Check** that `commit-commands:commit-push-pr` is available (the
+       Anthropic-published `commit-commands` plugin installs it).
+     - **If available:** one tool call to `commit-commands:commit-push-pr`.
+       No TaskCreate ceremony, no orchestration.
+     - **If not available:** output `commit-commands:commit-push-pr not
+       installed, falling back to local skills` and invoke our `/commit` →
+       `/push` → `/pr` in sequence.
    - `-c -p` without `-pr`: `commit-commands:commit-push-pr` always creates a
      PR, so for "commit + push only" invoke our `/commit` followed by `/push`.
    - `-pr` alone or alongside only `-d`/`-t`/`-r` (not `-c`/`-p`): invoke our

--- a/system-configs/.claude/skills/ship-it/SKILL.md
+++ b/system-configs/.claude/skills/ship-it/SKILL.md
@@ -2,7 +2,8 @@
 name: ship-it
 description: Orchestrate development workflows with composable flags. Use when shipping code through docs, test, commit, review, push, and PR stages.
 argument-hint: "[-d] [-t] [-c] [-r] [-p] [-pr] [--dry-run]"
-category: orchestration
+metadata:
+  category: orchestration
 ---
 
 # /ship-it
@@ -10,120 +11,103 @@ category: orchestration
 ## Usage
 
 ```bash
-/ship-it                    # Full: docs → test → commit → review → push → pr
-/ship-it -c -p              # Quick: commit → push
-/ship-it -t -c -p           # Test first: test → commit → push
-/ship-it -r -c -p           # Review gate: commit → review → push
+/ship-it                    # Full: docs → test → review → commit-push-pr
+/ship-it -c -p              # Quick: delegate commit+push to commit-commands:commit-push-pr (no PR)
+/ship-it -t -c -p           # Test first, then commit+push
+/ship-it -r -c -p           # Review gate, then commit+push
 /ship-it -d -t -c -r -p     # Everything except PR
-/ship-it -pr                # Just create PR
-/ship-it --dry-run          # Preview full workflow
+/ship-it -pr                # Just create PR (uses /pr for CodeRabbit acknowledgment if present)
+/ship-it --dry-run          # Preview without executing
 ```
 
 ## Description
 
-Pure orchestrator that composes workflow steps. Each flag enables a step.
-With no flags, runs the full workflow.
+A thin orchestrator that runs heavy optional steps (docs, test, review) and
+then delegates the commit/push/pr triplet to the Anthropic-published
+`commit-commands:commit-push-pr` skill — a 21-line skill that does all three
+git operations in a single tool message. That's the lean common path.
+
+When a step needs features specific to our skills (e.g., the CodeRabbit
+PR-comment integration in `/pr`, or `--dry-run` in `/push`), `/ship-it` falls
+back to invoking our own skill instead.
 
 ## Flags
 
-| Flag | Command |
-|------|---------|
-| `-d` | `/docs` |
-| `-t` | `/test` |
-| `-c` | `/commit` |
-| `-r` | `/review` |
-| `-p` | `/push` |
-| `-pr` | `/pr` |
-| `--dry-run` | Preview only |
+| Flag | What it enables |
+|------|-----------------|
+| `-d` | Run `/docs` first |
+| `-t` | Run `/test` first |
+| `-r` | Run `/review` first |
+| `-c -p -pr` | Commit + push + PR (delegated to `commit-commands:commit-push-pr`) |
+| `-c -p` (no `-pr`) | Commit + push only (`commit-commands:commit-push-pr` without the PR step is not available, so fall back to `/commit` + `/push`) |
+| `-c` alone | Run `/commit` only |
+| `-p` alone | Run `/push` only |
+| `-pr` alone | Create PR via `/pr` (preserves `--draft`, CodeRabbit acknowledgment) |
+| Other combinations | Any other partial combination (e.g., `-c -pr` without `-p`) is rejected with an error. |
+| `--dry-run` | Print the plan, don't execute |
 
-## Execution Script
+## Execution
 
-```text
-STEP 1: Parse flags
-  PARSE: $ARGUMENTS for flags: -d, -t, -c, -r, -p, -pr, --dry-run
+Parse flags from `$ARGUMENTS`. With no flags, enable every step.
 
-  IF: no step flags provided
-    SET: enabled_steps = [docs, test, commit, review, push, pr]
-  ELSE:
-    SET: enabled_steps = [flags that were provided]
+Run enabled steps in this fixed order; halt immediately on failure:
 
-  SORT: enabled_steps by fixed order: docs → test → commit → review → push → pr
-  OUTPUT: "🚀 ship-it: {enabled_steps joined by ' → '}"
+1. **`-d`**: Invoke `/docs`. Skip if no doc-relevant changes detected.
+2. **`-t`**: Invoke `/test`.
+3. **`-r`**: Invoke `/review`. If issues found, hand off to `/resolve-comments` per its own flow.
+4. **Commit + push + PR** (after any of -d/-t/-r have run): pick the right path
+   based on which of `-c`, `-p`, `-pr` are set (in the no-flag default, all
+   three are set, so this step runs `commit-commands:commit-push-pr`):
+   - All three of `-c -p -pr` set (including the no-flag default): one tool
+     call to `commit-commands:commit-push-pr`. No TaskCreate ceremony, no
+     orchestration.
+   - `-c -p` without `-pr`: `commit-commands:commit-push-pr` always creates a
+     PR, so for "commit + push only" invoke our `/commit` followed by `/push`.
+   - `-pr` alone or alongside only `-d`/`-t`/`-r` (not `-c`/`-p`): invoke our
+     `/pr` so the CodeRabbit comment integration (via
+     `.tmp/coderabbit-ignored.json`) and flags like `--draft` work.
+   - `-c` alone: invoke our `/commit`.
+   - `-p` alone: invoke our `/push`.
+   - Other partial combinations (e.g., `-c -pr` without `-p`): reject with a
+     clear error before doing any work.
 
-STEP 2: Dry-run check
-  IF: --dry-run flag set
-    OUTPUT: "Steps that would execute:\n{foreach step: '  📋 /{step}'}"
-    END
+Why delegate to `commit-commands:commit-push-pr` for the common case: it does
+status + commit + push + `gh pr create` in a single message with parallel tool
+calls (its frontmatter pre-injects `git status`, `git diff HEAD`, and the
+current branch — no extra round-trips). For routine ship-it invocations, that
+beats our previous chain of TaskCreate ceremony + 3 sequential sub-skills.
 
-STEP 3: Create task plan with dependencies
-  USE: TaskCreate for each enabled step with proper dependencies
+## Dry-run
 
-  Example task creation (for full workflow):
-    TaskCreate: "Generate documentation" (no blockers)
-    TaskCreate: "Run test suite" (no blockers - can run parallel with docs)
-    TaskCreate: "Create semantic commit" (blockedBy: docs, test)
-    TaskCreate: "Execute code review" (blockedBy: commit)
-    TaskCreate: "Push to remote" (blockedBy: review)
-    TaskCreate: "Create pull request" (blockedBy: push)
-
-  USE: TaskUpdate to set dependencies between tasks:
-    - commit blocked by: docs, test (both must complete first)
-    - review blocked by: commit
-    - push blocked by: review
-    - pr blocked by: push
-
-STEP 4: Execute with progress tracking
-  FOR_EACH: unblocked task in task list (use TaskList to find next)
-    TaskUpdate: task → in_progress
-    OUTPUT: "📋 {task.activeForm}..."
-
-    Command: "/{step}"
-    WAIT: for command completion
-
-    IF: command returned failure
-      OUTPUT: "❌ Step '{step}' failed. Halting."
-      TaskList: show current progress
-      END
-
-    TaskUpdate: task → completed
-    OUTPUT: "✅ {step} complete"
-
-STEP 5: Summary
-  TaskList: show final status
-  OUTPUT: "🎉 Complete ({completed_count}/{total_steps} steps)"
-  END
-```
+When `--dry-run` is set, print the enabled steps and which path will run for
+the commit/push/pr triplet. Don't execute anything.
 
 ## Expected Output
 
 ```text
-🚀 ship-it: docs → test → commit → review → push → pr
+🚀 ship-it: docs → test → review → commit-push-pr
 
-📋 Step 1/6: docs
-  ✅ docs complete
+📋 /docs
+  ✅ done
 
-📋 Step 2/6: test
-  ✅ test complete
+📋 /test
+  ✅ done
 
-📋 Step 3/6: commit
-  ✅ commit complete
+📋 /review
+  ✅ done
 
-📋 Step 4/6: review
-  ✅ review complete
-
-📋 Step 5/6: push
-  ✅ push complete
-
-📋 Step 6/6: pr
-  ✅ pr complete
-
-🎉 Complete (6/6 steps)
-PR: https://github.com/org/repo/pull/123
+📋 commit-commands:commit-push-pr
+  ✅ commit + push + PR
+  PR: https://github.com/org/repo/pull/123
 ```
 
 ## Notes
 
-- Pure orchestrator: invokes commands and halts on failure
-- Steps always execute in fixed order: docs → test → commit → review → push → pr
-- Each command handles its own validation (main/master checks, existing PR, etc.)
-- Halts immediately on any step failure
+- Halts immediately on any step failure.
+- `commit-commands:commit-push-pr` is published by Anthropic in the
+  `commit-commands` plugin. If it isn't installed, fall back to our `/commit` +
+  `/push` + `/pr` chain.
+- `/pr` retains its CodeRabbit-acknowledgment behavior — `/ship-it -pr` (or any
+  path that uses our `/pr`) will post the `.tmp/coderabbit-ignored.json` summary
+  to the PR.
+- Each invoked command handles its own validation (main/master checks, existing PR, etc.).

--- a/system-configs/.claude/skills/test/SKILL.md
+++ b/system-configs/.claude/skills/test/SKILL.md
@@ -2,7 +2,8 @@
 name: test
 description: Auto-discover and run tests for any project. Use when running or creating tests.
 argument-hint: "[--create|--framework|--coverage]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /test

--- a/system-configs/.claude/skills/testing-patterns/SKILL.md
+++ b/system-configs/.claude/skills/testing-patterns/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: testing-patterns
 description: TDD/BDD patterns, fixture strategies, and coverage requirements for consistent test engineering.
-category: workflow
 user-invocable: false
+metadata:
+  category: workflow
 ---
 
 # Testing Patterns Reference

--- a/system-configs/.claude/skills/verify/SKILL.md
+++ b/system-configs/.claude/skills/verify/SKILL.md
@@ -2,7 +2,8 @@
 name: verify
 description: Verify command execution met requirements. Use when confirming a command or skill completed correctly.
 argument-hint: "[--last|--command|--report-only]"
-category: workflow
+metadata:
+  category: workflow
 ---
 
 # /verify


### PR DESCRIPTION
## Summary

- **Removed TeamCreate from 3 default skills** (`review`, `fix-ci`, `implement`). Replaced with plain subagent fan-out (parallel `Task` calls in a single message). Same parallelism, no on-disk team state, no `SendMessage shutdown_request`/`TeamDelete` lifecycle, no deferred-tool round-trips for `TeamCreate`/`SendMessage`/`TeamDelete` schemas.
- **Aligned skill frontmatter to the Anthropic Agent Skills spec** (https://agentskills.io/specification). Moved non-spec `category:` to `metadata.category:` across all 27 skills; removed non-spec `agent:` field from `debug`, `docs`, `plan`, `prime` (no script read it; bodies still spawn the same agents via prose).
- **Trimmed `review/SKILL.md` 528 → 255 lines** via progressive disclosure. Four large embedded reviewer prompts moved to `system-configs/.claude/skills/review/references/{code,security,a11y,single}-review-prompt.md` — load on-demand only when reviewers fan out.
- **Rewrote `/ship-it` as a lean delegator.** Drops the TaskCreate/TaskUpdate orchestration ceremony. Default path delegates the commit+push+PR triplet to the Anthropic-published `commit-commands:commit-push-pr` skill (21 lines, single-message parallel git ops). Falls back to our `/commit`, `/push`, `/pr` only when their unique features are needed (CodeRabbit acknowledgment, `--force-with-lease`, `--dry-run`, `--amend`, `--draft`).
- **Security fix in `fix-ci`**: diagnoser output paths now use sequential `.tmp/diagnosis-N.json` with `job_name` stored as a field, eliminating filesystem injection risk from unsanitized CI job names.
- **Docs**: updated `ARCHITECTURE.md` diagram label and the two `SKILL_TEMPLATE` examples to reflect the new conventions.

Net diff: **+547 / -594** across 34 files (4 new files under `review/references/`).

## Test plan

- [x] `./tests/test.sh` — 19/19 pass (was 18/19 before fixing markdown lint nits)
- [x] `python3 scripts/test-config-integrity.py` — 6/6 pass
- [x] `python3 scripts/validate-agent-yaml.py` — 9/9 agents valid
- [x] `python3 scripts/check-orphans.py` — clean
- [x] `npx markdownlint-cli2 '**/*.md'` — 0 errors
- [x] `./scripts/sync.sh` — successful local deploy
- [ ] CI pipeline passes on push
- [ ] Sanity-run new `/ship-it` (no flags) on a follow-up branch and confirm it delegates to `commit-commands:commit-push-pr` in one message
- [ ] Sanity-run `/review --deep` on a small diff and confirm the three reference prompts load correctly from `references/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture diagram to describe parallel subagent fan-out.
  * Reorganized skill templates and frontmatter to nest metadata consistently.

* **Enhanced Features**
  * Switched multiple workflow docs to a parallel subagent fan-out model instead of team-based execution.
  * Added specialized review prompts for accessibility, security, and code-quality checks.
  * Clarified orchestration patterns for streamlined parallel task execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damilola-elegbede-org/claude-config/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->