### PR TITLE
fix(hooks): add explicit timeout to SessionEnd hook

### DIFF
--- a/system-configs/.claude/settings.json
+++ b/system-configs/.claude/settings.json
@@ -115,7 +115,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${HOME}/.claude/exit_hook.sh"
+            "command": "${HOME}/.claude/exit_hook.sh",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
## Summary
Adds an explicit `"timeout": 10` to the `SessionEnd` hook in `settings.json`, preventing the \"Hook cancelled\" error shown at session teardown.

## Changes
- Added `"timeout": 10` to the `SessionEnd` hook entry in `system-configs/.claude/settings.json`

## Context
Without a configured timeout, Claude Code has no deadline for the `SessionEnd` hook and cancels it during session cleanup with the error:

```
SessionEnd hook [${HOME}/.claude/exit_hook.sh] failed: Hook cancelled
```

The `SessionStart` hook already has `"timeout": 5` — this aligns `SessionEnd` with the same pattern, giving it a 10-second window (slightly more generous since the exit hook does a version file read/write and optional `claude --version` call).

## Testing
All 19 config tests pass, including the \"Exit hook functionality\" test that validates the hook correctly reads version from stdin and preserves the version flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added timeout safeguard to session termination handler to prevent indefinite waits during shutdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damilola-elegbede-org/claude-config/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->